### PR TITLE
Fix for #63: no-unexpected-multiline issue

### DIFF
--- a/src/rules/noUnexpectedMultilineRule.ts
+++ b/src/rules/noUnexpectedMultilineRule.ts
@@ -4,7 +4,8 @@ import * as Lint from 'tslint/lib/lint';
 export class Rule extends Lint.Rules.AbstractRule {
   public static FAILURE_STRING = {
     func: 'unexpected newline between function and ( of function call',
-    prop: 'unexpected newline between object and [ of property access'
+    prop: 'unexpected newline between object and [ of property access',
+    template: 'unexpected newline between template tag and template literal'
   };
 
   public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
@@ -14,31 +15,81 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 class NoUnexpectedMultilineWalker extends Lint.RuleWalker {
-  protected visitNode(node: ts.Node) {
-    this.validateMultiline(node);
-    super.visitNode(node);
+
+  protected visitCallExpression(node: ts.CallExpression): void {
+    const firstLeftParen = node.getChildren().filter(ch => ch.kind === ts.SyntaxKind.OpenParenToken)[0];
+    if (this.isBreakBefore(firstLeftParen)) {
+      this.addFailure(this.createFailure(node.getStart(), node.getWidth(), this.getMessage(node)));
+    }
+
+    super.visitCallExpression(node);
   }
 
-  private getMessage(node: ts.Node) {
-    return node.kind === ts.SyntaxKind.CallExpression ? Rule.FAILURE_STRING.func : Rule.FAILURE_STRING.prop;
+  protected visitElementAccessExpression(node: ts.ElementAccessExpression): void {
+    const firstLeftSquareBracket = node.getChildren().filter(ch => ch.kind === ts.SyntaxKind.OpenBracketToken)[0];
+    if (this.isBreakBefore(firstLeftSquareBracket)) {
+      this.addFailure(this.createFailure(node.getStart(), node.getWidth(), this.getMessage(node)));
+    }
+
+    super.visitElementAccessExpression(node);
   }
 
-  private getPosition(node: ts.Node) {
-    return node.getSourceFile().getLineAndCharacterOfPosition(node.getStart());
-  }
+  // it doesn't seem like there's a visitTaggedTemplateExpression() method, 
+  // so we'll looks for TaggedTemplateExpressions ourselves
+  protected visitNode(node: ts.Node): void {
+    if (node.kind === ts.SyntaxKind.TaggedTemplateExpression) {
+      const children = node.getChildren();
+      const tag = children.filter(ch => ch.kind === ts.SyntaxKind.Identifier)[0];
+      const tagIndex = children.indexOf(tag);
 
-  private validateMultiline(node: ts.Node) {
-    const parent = node.parent;
-
-    if (parent) {
-      const before = parent.getChildAt(parent.getChildren().indexOf(node) - 1);
-      const paren = parent.getChildAt(parent.getChildren().indexOf(node) - 2);
-
-      if (before && paren) {
-        if (this.getPosition(before).line !== this.getPosition(paren).line) {
+      if (tag && children[tagIndex + 1]) {
+        // the template is always the next syntax element after the tag
+        const template = children[tagIndex + 1];
+        if (this.isBreakBefore(template)) {
           this.addFailure(this.createFailure(node.getStart(), node.getWidth(), this.getMessage(node)));
         }
       }
     }
+
+    super.visitNode(node);
+  }
+
+  private isBreakBefore(node: ts.Node): boolean {
+    if (node.parent) {
+      const children = node.parent.getChildren();
+      const nodeIndex = children.indexOf(node);
+
+      if (nodeIndex > 0) {
+        const nodeLine = this.getStartPosition(node).line;
+        const previousNodeLine = this.getEndPosition(children[nodeIndex - 1]).line;
+
+        if (nodeLine !== previousNodeLine) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  private getMessage(node: ts.Node) {
+    switch (node.kind) {
+      case ts.SyntaxKind.CallExpression:
+        return Rule.FAILURE_STRING.func;
+      case ts.SyntaxKind.ElementAccessExpression:
+        return Rule.FAILURE_STRING.prop;
+      case ts.SyntaxKind.TaggedTemplateExpression:
+        return Rule.FAILURE_STRING.template;
+      default:
+        throw 'Unexpected node type: ' + ts.SyntaxKind[node.kind];
+    }
+  }
+
+  private getStartPosition(node: ts.Node) {
+    return node.getSourceFile().getLineAndCharacterOfPosition(node.getStart());
+  }
+
+  private getEndPosition(node: ts.Node) {
+    return node.getSourceFile().getLineAndCharacterOfPosition(node.getEnd());
   }
 }

--- a/src/test/rules/noUnexpectedMultilineRuleTests.ts
+++ b/src/test/rules/noUnexpectedMultilineRuleTests.ts
@@ -47,6 +47,20 @@ const scripts = {
       function a() {
 
       }
+    `,
+    `
+      if (a === 1
+        && (b === 2 || c === 3)) { }
+    `,
+    `
+      myArray
+        .map();
+    `,
+    `
+      tag \`hello world\`
+    `,
+    `
+      tag \`hello \${expression} world\`
     `
   ],
   invalid: [
@@ -73,16 +87,24 @@ const scripts = {
     `
       var a = b
         [a, b, c].forEach(doSomething)
+    `,
+    `
+      tag
+        \`hello world\`
+    `,
+    `
+      tag
+        \`hello \${expression} world\`
     `
   ]
 };
 
 describe(rule, function test() {
-  it('should pass when using expected parenthesis and brackets', function testValid() {
+  it('should pass when using expected parenthesis, brackets, or templates', function testValid() {
     makeTest(rule, scripts.valid, true);
   });
 
-  it('should fail when using unexpected parenthesis or brackets', function testInvalid() {
+  it('should fail when using unexpected parenthesis, brackets, or templates', function testInvalid() {
     makeTest(rule, scripts.invalid, false);
   });
 });


### PR DESCRIPTION
Fixes #63.  Also adds support for similar situations with template tags (see http://eslint.org/docs/rules/no-unexpected-multiline).

Note: I modified the implementation of this rule fairly heavily in order to more closely align with the implementation of the corresponding eslint rule: https://github.com/eslint/eslint/blob/master/lib/rules/no-unexpected-multiline.js.