### PR TITLE
Possible fix for #60

### DIFF
--- a/src/test/rules/noControlRegexRuleTests.ts
+++ b/src/test/rules/noControlRegexRuleTests.ts
@@ -9,12 +9,15 @@ const scripts = {
     'var regex = RegExp("x1f")',
     'new RegExp("[")',
     'RegExp("[")',
-    'new (function foo(){})("\\x1f")'
+    'new (function foo(){})("\\x1f")',
+    'var regex = /\\\\x20/;',
+    'var regex = new RegExp("\\x20");'
   ],
   'invalid': [
     'var regex = /\\\u001f/',
     'var regex = new RegExp("\\x1f")',
-    'var regex = RegExp("\\x1f")'
+    'var regex = RegExp("\\x1f")',
+    'var regex = /\\\\x1f/;'
   ]
 };
 


### PR DESCRIPTION
Possible fix for #60.

The issue turned out to be a difference in how escape characters are specified in literal regular expression and regular expression created using `new RegExp(...)`.  This PR solves the issue, but not necessarily in an ideal way -  in order to get a string with real control characters from a regex literal, I had to `eval()` a processed version of the literal regex's string representation.  I won't be offended if you reject this PR in favor or a more elegant solution.