### PR TITLE
Fix `validateReferenceForVariable` call

### DIFF
--- a/src/rules/handleCallbackErrRule.ts
+++ b/src/rules/handleCallbackErrRule.ts
@@ -39,7 +39,7 @@ class ErrCallbackHandlerWalker extends Lint.RuleWalker {
     private validateReferencesForVariable(name: string, position: number) {
         const fileName = this.getSourceFile().fileName;
         const highlights = this.languageService.getDocumentHighlights(fileName, position, [fileName]);
-        if (highlights === null || highlights[0].highlightSpans.length <= 1) {
+        if (highlights == null || highlights[0].highlightSpans.length <= 1) {
           this.addFailure(this.createFailure(position, name.length, `${Rule.FAILURE_STRING}'${name}'`));
         }
     }

--- a/src/rules/handleCallbackErrRule.ts
+++ b/src/rules/handleCallbackErrRule.ts
@@ -39,7 +39,7 @@ class ErrCallbackHandlerWalker extends Lint.RuleWalker {
     private validateReferencesForVariable(name: string, position: number) {
         const fileName = this.getSourceFile().fileName;
         const highlights = this.languageService.getDocumentHighlights(fileName, position, [fileName]);
-        if (highlights == null || highlights[0].highlightSpans.length <= 1) {
+        if (!highlights || highlights[0].highlightSpans.length <= 1) {
           this.addFailure(this.createFailure(position, name.length, `${Rule.FAILURE_STRING}'${name}'`));
         }
     }


### PR DESCRIPTION
Closes https://github.com/buzinas/tslint-eslint-rules/issues/90.