### PR TITLE
[fix] add namespaces as valid location for function declaration

### DIFF
--- a/src/rules/noInnerDeclarationsRule.ts
+++ b/src/rules/noInnerDeclarationsRule.ts
@@ -15,7 +15,8 @@ class NoInnerDeclarationsWalker extends Lint.RuleWalker {
     ts.SyntaxKind.FunctionDeclaration,
     ts.SyntaxKind.FunctionExpression,
     ts.SyntaxKind.ArrowFunction,
-    ts.SyntaxKind.MethodDeclaration
+    ts.SyntaxKind.MethodDeclaration,
+    ts.SyntaxKind.ModuleDeclaration
   ];
 
   protected visitFunctionDeclaration(node: ts.FunctionDeclaration) {

--- a/src/rules/noInnerDeclarationsRule.ts
+++ b/src/rules/noInnerDeclarationsRule.ts
@@ -16,7 +16,8 @@ class NoInnerDeclarationsWalker extends Lint.RuleWalker {
     ts.SyntaxKind.FunctionExpression,
     ts.SyntaxKind.ArrowFunction,
     ts.SyntaxKind.MethodDeclaration,
-    ts.SyntaxKind.ModuleDeclaration
+    ts.SyntaxKind.ModuleDeclaration,
+    ts.SyntaxKind.Constructor
   ];
 
   protected visitFunctionDeclaration(node: ts.FunctionDeclaration) {

--- a/src/test/rules/noInnerDeclarationsRuleTests.ts
+++ b/src/test/rules/noInnerDeclarationsRuleTests.ts
@@ -17,7 +17,8 @@ const scripts = {
     'if (test) { var foo; }',
     'function doSomething() { while (test) { var foo; } }',
     'foo(() => { function bar() { } });',
-    'namespace something { function decl(arg) { var foo; } }'
+    'namespace something { function decl(arg) { var foo; } }',
+    'class MyClass { constructor(arg) { function decl(x) { var foo; } } }'
   ],
   validBoth: [
     'if (test) { let x = 1; }',

--- a/src/test/rules/noInnerDeclarationsRuleTests.ts
+++ b/src/test/rules/noInnerDeclarationsRuleTests.ts
@@ -16,7 +16,8 @@ const scripts = {
     'function decl(arg) { var fn; if (arg) { fn = function expr() { }; } }',
     'if (test) { var foo; }',
     'function doSomething() { while (test) { var foo; } }',
-    'foo(() => { function bar() { } });'
+    'foo(() => { function bar() { } });',
+    'namespace something { function decl(arg) { var foo; } }'
   ],
   validBoth: [
     'if (test) { let x = 1; }',


### PR DESCRIPTION
As far as I can tell, the rule about declaring nested functions is as follows:

In strict mode, function declarations cannot be nested inside a statement or block. They may only appear at the top level or directly inside a function body.

Thus, if you declare

```TypeScript
namespace MyNamespace {
  function MyHelperFunction() {
    console.log("This _should_ be allowed.");
  }
}
```

it will be compiled into something that looks vaguely like this (depending on your module output setting)

```JavaScript
var MyNamespace;
(function (MyNamespace) {
  function MyHelperFunction() {
    console.log("This _should_ be allowed.");
  }
})(MyNamespace || (MyNamespace = {}));
```

This, therefore, does not violate the rule about nested functions, but the linter still marks it as invalid.  I propose we add `ts.SyntaxKind.ModuleDeclaration` to the list of valid parent types in noInnerDeclarationsRule.ts and the appropriate associated test case.