### PR TITLE
Object curly spacing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 .idea
 dist
+src/**/*.js
 generate-changelog.bat

--- a/README.md
+++ b/README.md
@@ -1845,7 +1845,7 @@ These rules are purely matters of style and are quite subjective.
     "no-whitespace-before-property": true
     ```
 
-* [object-curly-spacing](http://eslint.org/docs/rules/object-curly-spacing) => object-curly-spacing (tslint-eslint-rules) [TODO]()
+* [object-curly-spacing](http://eslint.org/docs/rules/object-curly-spacing) => object-curly-spacing (tslint-eslint-rules)
   * Description: require or disallow padding inside curly braces
   * Usage
 

--- a/README.md
+++ b/README.md
@@ -2586,7 +2586,8 @@ If you didn't find the rule, you can also create an ESLint custom rule for TSLin
   - Name: rule-name (hyphenated, e.g: no-if-usage)
   - File: ruleNameRule.ts (camelCased and with the `Rule` suffix, e.g: noIfUsageRule.ts)
   - Test File: ruleNameRuleTests.ts (camelCased and with the `RuleTests` suffix, e.g: noIfUsageRuleTests.ts)
-- Check if all the tests are passing
+- Check if single rule is passing with `gulp test --single rule-name` (hyphenated, e.g no-inner-declarations)
+- Check if all the tests are passing with `gulp test`
 - Commit the changes to your repo with the following convention:
   - Example: `[feat] added use-isnan rule (closes #20)`
 - Finally, open a Pull Request

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,7 +42,7 @@ gulp.task('lint', function lint() {
     }));
 });
 
-gulp.task('build', ['lint'], function build() {
+gulp.task('build', argv.lint === false ? [] : ['lint'], function build() {
   return gulp
     .src([SRC_FOLDER, DEF_FOLDER, 'node_modules/typescript/lib/lib.es6.d.ts'])
     .pipe(sourcemaps.init())

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const argv = require('yargs').argv;
 const path = require('path');
 const gulp = require('gulp');
 const sourcemaps = require('gulp-sourcemaps');
@@ -7,7 +8,26 @@ const ts = require('gulp-typescript');
 const tslint = require('gulp-tslint');
 const mocha = require('gulp-spawn-mocha');
 
-const SRC_FOLDER = 'src/**/*.ts';
+
+function toCamelCase(str){
+  const words = str.split('-').map(function(word){
+    return word.charAt(0).toUpperCase() + word.slice(1);
+  });
+  words[0] = words[0].toLowerCase();
+  return words.join('');
+}
+
+function singleRule(name) {
+  return `src/**/?(${toCamelCase(name)}*|helper).ts`;
+}
+
+function singleTest(name) {
+  return `dist/test/rules/${toCamelCase(name)}RuleTests.js`;
+}
+
+
+const SRC_FOLDER = argv.single ? singleRule(argv.single) : 'src/**/*.ts';
+const TEST_FOLDER = argv.single ? singleTest(argv.single) : 'dist/test/**/*.js';
 const DEF_FOLDER = 'typings/**/*.ts'
 const TS_CONFIG = ts.createProject('tsconfig.json');
 
@@ -36,7 +56,7 @@ gulp.task('build', ['lint'], function build() {
 
 gulp.task('test', ['build'], function test() {
   return gulp
-    .src('dist/test/**/*.js')
+    .src(TEST_FOLDER)
     .pipe(mocha());
 });
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "gulp-tslint": "^3.6.0",
     "gulp-typescript": "^2.12.1",
     "mocha": "^2.4.5",
-    "typescript": "^1.8.9"
+    "typescript": "^1.8.9",
+    "yargs": "^5.0.0"
   },
   "dependencies": {
     "doctrine": "^0.7.2",

--- a/src/rules/objectCurlySpacingRule.ts
+++ b/src/rules/objectCurlySpacingRule.ts
@@ -1,0 +1,71 @@
+import * as ts from 'typescript';
+import * as Lint from 'tslint/lib/lint';
+
+const OPTION_ALWAYS = 'always';
+
+export class Rule extends Lint.Rules.AbstractRule {
+  public static FAILURE_STRING = {
+    always: {
+      start: `A space is required after '{'`,
+      end: `A space is required before '}'`
+    },
+    never: {
+      start: `There should be no space after '{'`,
+      end: `There should be no space before '}'`
+    }
+  };
+
+  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    const walker = new BlockSpacingWalker(sourceFile, this.getOptions());
+    return this.applyWithWalker(walker);
+  }
+}
+
+class BlockSpacingWalker extends Lint.RuleWalker {
+
+  private always: boolean;
+
+  constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
+    super(sourceFile, options);
+    this.always = this.hasOption(OPTION_ALWAYS) || (this.getOptions() && this.getOptions().length === 0);
+  }
+
+  protected visitNode(node: ts.Node): void {
+    const bracedKind = [
+      ts.SyntaxKind.ObjectLiteralExpression,
+      ts.SyntaxKind.ObjectBindingPattern,
+      ts.SyntaxKind.NamedImports,
+      ts.SyntaxKind.NamedExports
+    ];
+    if (bracedKind.indexOf(node.kind) > -1) {
+      this.checkSpacingInsideBraces(node);
+    }
+    super.visitNode(node);
+  }
+
+  private checkSpacingInsideBraces(node: ts.Node): void {
+    const text = node.getText();
+    if (text.indexOf('\n') !== -1 || text === '{}') {
+      // Rule does not apply when the braces span multiple lines
+      return;
+    }
+    const leadingSpace = text.match(/^\{(\s{0,2})/)[1].length;
+    const trailingSpace = text.match(/(\s{0,2})}$/)[1].length;
+    if (this.always) {
+      if (leadingSpace === 0) {
+        this.addFailure(this.createFailure(node.getStart(), 1, Rule.FAILURE_STRING.always.start));
+      }
+      if (trailingSpace === 0) {
+        this.addFailure(this.createFailure(node.getEnd() - 1, 1, Rule.FAILURE_STRING.always.end));
+      }
+    } else {
+      if (leadingSpace > 0) {
+        this.addFailure(this.createFailure(node.getStart(), 1, Rule.FAILURE_STRING.never.start));
+      }
+      if (trailingSpace > 0) {
+        this.addFailure(this.createFailure(node.getEnd() - 1, 1, Rule.FAILURE_STRING.never.end));
+      }
+    }
+  }
+
+}

--- a/src/rules/objectCurlySpacingRule.ts
+++ b/src/rules/objectCurlySpacingRule.ts
@@ -16,12 +16,12 @@ export class Rule extends Lint.Rules.AbstractRule {
   };
 
   public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-    const walker = new BlockSpacingWalker(sourceFile, this.getOptions());
+    const walker = new ObjectCurlySpacingWalker(sourceFile, this.getOptions());
     return this.applyWithWalker(walker);
   }
 }
 
-class BlockSpacingWalker extends Lint.RuleWalker {
+class ObjectCurlySpacingWalker extends Lint.RuleWalker {
 
   private always: boolean;
 

--- a/src/test/rules/objectCurlySpacingRuleTests.ts
+++ b/src/test/rules/objectCurlySpacingRuleTests.ts
@@ -1,0 +1,60 @@
+/// <reference path='../../../typings/mocha/mocha.d.ts' />
+import { makeTest } from './helper';
+
+const rule = 'object-curly-spacing';
+const scripts = {
+  always: {
+    valid: [
+      `const obj = { foo: 'bar' };`,
+      `const obj = { foo: { zoo: 'bar' } };`,
+      `const { x, y } = y;`,
+      `import { foo } from 'bar';`,
+      `export { foo };`
+    ],
+    invalid: [
+      `const obj = {foo: 'bar'};`,
+      `const obj = {foo: { zoo: 'bar' } };`,
+      `const {x, y} = y;`,
+      `import {foo } from 'bar';`,
+      `export { foo};`
+    ]
+  },
+  never: {
+    valid: [
+      `const obj = {foo: 'bar'};`,
+      `const obj = {foo: {zoo: 'bar'}};`,
+      `const {x, y} = y;`,
+      `import {foo} from 'bar';`,
+      `export {foo};`
+    ],
+    invalid: [
+      `const obj = { foo: 'bar' };`,
+      `const obj = { foo: { zoo: 'bar' } };`,
+      `const { x, y } = y;`,
+      `import {foo } from 'bar';`,
+      `export { foo};`
+    ]
+  }
+};
+
+describe(rule, function test() {
+
+  const alwaysConfig = { rules: { 'object-curly-spacing': [true, 'always'] } };
+  const neverConfig = { rules: { 'object-curly-spacing': [true, 'never'] } };
+
+  it('should pass when "always" and there are spaces inside brackets', function testVariables() {
+    makeTest(rule, scripts.always.valid, true, alwaysConfig);
+  });
+
+  it('should fail when "always" and there are not spaces inside brackets', function testVariables() {
+    makeTest(rule, scripts.always.invalid, false, alwaysConfig);
+  });
+
+  it('should pass when "never" and there are not spaces inside brackets', function testVariables() {
+    makeTest(rule, scripts.never.valid, true, neverConfig);
+  });
+
+  it('should fail when "never" and there are spaces inside brackets', function testVariables() {
+    makeTest(rule, scripts.never.invalid, false, neverConfig);
+  });
+});

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,10 @@
 {
+  "rulesDirectory": ["dist/rules/"],
   "rules": {
+    "object-curly-spacing": [
+      false,
+      "always"
+    ],
     "align": [
       true,
       "parameters",

--- a/tslint.json
+++ b/tslint.json
@@ -1,10 +1,5 @@
 {
-  "rulesDirectory": ["dist/rules/"],
   "rules": {
-    "object-curly-spacing": [
-      false,
-      "always"
-    ],
     "align": [
       true,
       "parameters",


### PR DESCRIPTION
This PR adds the `object-curly-spacing` rules according to specifications from [eslint](http://eslint.org/docs/rules/object-curly-spacing.html). The rule and test files have have been added and the README file has been updated to show that it is no longer in the TODO list.

Several other changes have been made in order to improve the developing experience.

- **No longer running all the tests to check if the rule in development works**:

  By default `gulp test` will run all the tests that it can find. We can now target a particular
  test by using the `single` argument as explained in the README: `gulp test --single rule-name`.

- **Transpile files even if linting fails**:

  When running the tests we always run the build task which depends on the linting task.
  Sometimes we may encounter linting errors that we are not willing to clean up yet and this
  should not stop us from writing the rule. When this is the case we can add the flag `--no-lint`
  so that the linting task is not triggered. For instance `gulp test --single rule-name --no-lint`.

I also added the rule to the project to test if we have inconsistencies in the project files. So far we are not adding spaces on imports but we do on object literals. In order to leave things working I have turned off the rule but we should consider using it in order to avoid future inconsistencies. I will open an issue for this.

Finally, the current state of the project is bad. Please test your master branch and let me know if you the `valid-jsdoc` test fails at `should fail when using invalid JSDoc comments (matchDescription: "regex", requireReturn: false)`.

   
   