### PR TITLE
[bug] fixed valid-jsdoc rule (closes #100)

### DIFF
--- a/src/rules/validJsdocRule.ts
+++ b/src/rules/validJsdocRule.ts
@@ -83,9 +83,9 @@ class ValidJsdocWalker extends Lint.SkippableTokenAwareRuleWalker {
     this.checkJSDoc(node);
   }
 
-  private visitClassExpression(node: ts.ClassExpression) {
+  protected visitClassExpression(node: ts.ClassExpression) {
     this.startFunction(node);
-    super.visitNode(node);
+    super.visitClassExpression(node);
     this.checkJSDoc(node);
   }
 


### PR DESCRIPTION
Currently we run into an infinite loop when calling `ValidJsdocWalker::visitClassExpression`. This method cannot be private since `Lint.SkippableTokenAwareRuleWalker` does not define it as private.

Inside `visitClassExpression` we have a call to `super.visitNode`. This will excute the `Lint.SkippableTokenAwareRuleWalker.visitNode` method which has this code:

```typescript
case ts.SyntaxKind.ClassExpression:
    this.visitClassExpression(node);
    break;
```

And what will be called with `this.visitClassExpression`? the one in `Lint.SkippableTokenAwareRuleWalker` or `ValidJsdocWalker`? Since the one who was calling it was `ValidJsdocWalker` we end up calling the one function we overwrote, that is

```typescript
  private visitClassExpression(node: ts.ClassExpression) {
    this.startFunction(node);
    super.visitNode(node);
    this.checkJSDoc(node);
  }
```

And where will this take us? back to the switch statement in the parent class. And so we have the infinite loop.

The changes I made make it so that we avoid this and all the tests still pass. Let me know if this was not the intention, otherwise you may want to rename `visitClassExpression` to something else so that there is no question of which function the parent class should call. Either way, merging this should fix all the conflicts in all the other PRs.
