### PR TITLE
Fix `no-ex-assign` rule on non-assignment ops

### DIFF
--- a/src/rules/noConstantConditionRule.ts
+++ b/src/rules/noConstantConditionRule.ts
@@ -1,5 +1,6 @@
 import * as ts from 'typescript';
 import * as Lint from 'tslint/lib/lint';
+import { isAssignmentToken } from '../support/token';
 
 export class Rule extends Lint.Rules.AbstractRule {
   public static FAILURE_STRING = 'unexpected constant condition';
@@ -87,7 +88,7 @@ class NoConstantConditionWalker extends Lint.RuleWalker {
       // ESLint BinaryExpression / LogicalExpression
       case ts.SyntaxKind.BinaryExpression:
         // ESLint AssignmentExpression
-        if (this.isAssignmentToken((node as ts.BinaryExpression).operatorToken)) {
+        if (isAssignmentToken((node as ts.BinaryExpression).operatorToken)) {
           return this.isConstant((node as ts.BinaryExpression).right);
         }
         return this.isConstant((node as ts.BinaryExpression).left) && this.isConstant((node as ts.BinaryExpression).right);
@@ -103,9 +104,5 @@ class NoConstantConditionWalker extends Lint.RuleWalker {
     }
 
     return false;
-  }
-
-  private isAssignmentToken(token: ts.Node) {
-    return token.kind >= ts.SyntaxKind.FirstAssignment && token.kind <= ts.SyntaxKind.LastAssignment;
   }
 }

--- a/src/rules/noExAssignRule.ts
+++ b/src/rules/noExAssignRule.ts
@@ -1,5 +1,6 @@
 import * as ts from 'typescript';
 import * as Lint from 'tslint/lib/lint';
+import { isAssignmentToken } from '../support/token';
 
 export class Rule extends Lint.Rules.AbstractRule {
   public static FAILURE_STRING = 'do not assign to the exception parameter';
@@ -24,6 +25,10 @@ class NoExAssignWalker extends Lint.RuleWalker {
 
   protected visitBinaryExpression(node: ts.BinaryExpression) {
     if (this.isInCatchClause) {
+      if (!isAssignmentToken(node.operatorToken)) {
+        return;
+      }
+
       if (node.left.kind === ts.SyntaxKind.Identifier && this.variableNode.name.getText() === node.left.getText()) {
         this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
       }

--- a/src/support/token.ts
+++ b/src/support/token.ts
@@ -1,0 +1,5 @@
+import * as ts from 'typescript';
+
+export function isAssignmentToken(token: ts.Node) {
+  return token.kind >= ts.SyntaxKind.FirstAssignment && token.kind <= ts.SyntaxKind.LastAssignment;
+}

--- a/src/test/rules/noExAssignRuleTests.ts
+++ b/src/test/rules/noExAssignRuleTests.ts
@@ -62,10 +62,15 @@ const scripts = {
             done();
         });
     });
-    `
+    `,
+    'try {} catch (err) { if (err instanceof Foo) {} }',
+    'try {} catch (err) { if (err == err) {} }',
+    'try {} catch (err) { if (err === err) {} }'
   ],
   invalid: [
     'try { } catch (e) { e = 10; }',
+    'try { } catch (e) { e += 10; }',
+    'try { } catch (e) { e -= 10; }',
     'try { } catch (ex) { ex = 10; }',
     'try { } catch (ex) { [ex] = []; }',
     'try { } catch (ex) { ({x: ex = 0}) = {}; }',


### PR DESCRIPTION
Moves the `isAssignmentToken` function into a `support` folder for code reuse.

Closes https://github.com/buzinas/tslint-eslint-rules/issues/118.