### PR TITLE
Patch `handle-callback-err`

### DIFF
--- a/src/test/rules/handleCallbackErrRuleTests.ts
+++ b/src/test/rules/handleCallbackErrRuleTests.ts
@@ -11,13 +11,19 @@ const scripts = {
             console.log(err.stack);
         }
         doSomething();
-    }`,
+      }`,
       `function loadData (Err, data) {
         if (Err) {
             console.log(Err.stack);
         }
         doSomething();
-    }`
+      }`,
+      `function test (cb) {
+        doSomething(function (err) {
+          cb(err)
+        })
+      }`,
+      `function handle (arg, err) {}`
     ],
     invalid: [
       `function(err, stream) { stream.on('done', function(){exit(0)} }`,


### PR DESCRIPTION
* Improve usage of checking first character (the use of an `indexOf` when it should be a quick single character check always irks me)
* Only check the first parameter (consistent with ESLint behaviour)
* Update the failure string to match ESLint
* Fix the position usage to avoid highlighting unrelated whitespace

Closes https://github.com/buzinas/tslint-eslint-rules/issues/120.