### PR TITLE
Refactor the `handle-callback-err` rule

### DIFF
--- a/src/rules/handleCallbackErrRule.ts
+++ b/src/rules/handleCallbackErrRule.ts
@@ -26,21 +26,31 @@ class ErrCallbackHandlerWalker extends Lint.RuleWalker {
     }
   }
 
+  public visitFunctionExpression(node: ts.FunctionExpression) {
+    this.validateFunction(node);
+    super.visitFunctionExpression(node);
+  }
+
   public visitFunctionDeclaration(node: ts.FunctionDeclaration) {
-    const parameter = node.parameters[0];
-
-    if (parameter && this.errorCheck(parameter.name.getText())) {
-      this.validateReferencesForVariable(parameter);
-    }
-
+    this.validateFunction(node);
     super.visitFunctionDeclaration(node);
   }
 
-  private validateReferencesForVariable(node: ts.ParameterDeclaration) {
-    const fileName = this.getSourceFile().fileName;
-    const highlights = this.languageService.getDocumentHighlights(fileName, node.pos, [fileName]);
-    if (!highlights || highlights[0].highlightSpans.length <= 1) {
-      this.addFailure(this.createFailure(node.name.getStart(), node.name.getWidth(), Rule.FAILURE_STRING));
+  public visitArrowFunction(node: ts.ArrowFunction) {
+    this.validateFunction(node);
+    super.visitArrowFunction(node);
+  }
+
+  private validateFunction(node: ts.FunctionLikeDeclaration) {
+    const parameter = node.parameters[0];
+
+    if (parameter && this.errorCheck(parameter.name.getText())) {
+      const fileName = this.getSourceFile().fileName;
+      const highlights = this.languageService.getDocumentHighlights(fileName, parameter.pos, [fileName]);
+
+      if (!highlights || highlights[0].highlightSpans.length <= 1) {
+        this.addFailure(this.createFailure(parameter.name.getStart(), parameter.name.getWidth(), Rule.FAILURE_STRING));
+      }
     }
   }
 }

--- a/src/test/rules/handleCallbackErrRuleTests.ts
+++ b/src/test/rules/handleCallbackErrRuleTests.ts
@@ -28,12 +28,18 @@ const scripts = {
     invalid: [
       `function(err, stream) { stream.on('done', function(){exit(0)} }`,
       `function loadData (err, data) { doSomething(); }`,
+      `test(function (err) {
+        console.log('hello world')
+      })`,
+      `test(err => undefined)`,
+      `const cb = (err) => null`,
+      `var cb = function (err) {}`,
       `function loadData (err, data) {
         if (error) {
             console.log(error.stack);
         }
         doSomething();
-    }`
+      }`
     ]
   },
   customErrorNameConfig: {


### PR DESCRIPTION
The previous code only worked on function declarations, which is by far the least used syntax when it comes to callback handling. I updated the rule to also check function expressions and arrow functions.