### PR TITLE
[feat] ter-indent (closes #74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ These rules are purely matters of style and are quite subjective.
 |:x:|[id-blacklist](http://eslint.org/docs/rules/id-blacklist)|id-blacklist|disallow certain identifiers to prevent them being used|
 |:x:|[id-length](http://eslint.org/docs/rules/id-length)|id-length|this option enforces minimum and maximum identifier lengths (variable names, property names etc.)|
 |:x:|[id-match](http://eslint.org/docs/rules/id-match)|id-match|require identifiers to match the provided regular expression|
-|:ballot_box_with_check:|[indent](http://eslint.org/docs/rules/indent)|[indent](http://palantir.github.io/tslint/rules/indent)|specify tab or space width for your code|
+|:white_check_mark:|[indent](http://eslint.org/docs/rules/indent)|[ter-indent](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/docs/rules/terIndentRule.md)|enforce consistent indentation|
 |:x:|[jsx-quotes](http://eslint.org/docs/rules/jsx-quotes)|jsx-quotes|specify whether double or single quotes should be used in JSX attributes|
 |:x:|[key-spacing](http://eslint.org/docs/rules/key-spacing)|key-spacing|enforce spacing between keys and values in object literal properties|
 |:x:|[keyword-spacing](http://eslint.org/docs/rules/keyword-spacing)|keyword-spacing|enforce spacing before and after keywords|

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "author": "Vitor Buzinaro <buzinas@buzinas.com>",
   "license": "MIT",
   "devDependencies": {
-    "@types/object-assign": "^4.0.30",
     "chai": "^3.5.0",
     "es6-promise": "^4.0.4",
     "gulp": "^3.9.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "author": "Vitor Buzinaro <buzinas@buzinas.com>",
   "license": "MIT",
   "devDependencies": {
+    "@types/object-assign": "^4.0.30",
     "chai": "^3.5.0",
     "es6-promise": "^4.0.4",
     "gulp": "^3.9.1",

--- a/src/docs/rules/terIndentRule.md
+++ b/src/docs/rules/terIndentRule.md
@@ -1,0 +1,74 @@
+<!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
+## ter-indent (ESLint: [indent](http://eslint.org/docs/rules/indent))
+
+enforce consistent indentation
+
+### Usage
+
+```json
+"indent": [
+    true,
+    "tab"
+  ]
+```
+
+```json
+"indent": [
+    true,
+    2
+  ]
+```
+
+```json
+"indent": [
+    true,
+    2,
+    {
+      "FunctionExpression": {
+        "parameters": 1,
+        "body": 1
+      }
+    }
+  ]
+```
+
+<!-- End:AutoDoc -->
+
+### Rationale
+
+Using only one of tabs or spaces for indentation leads to more consistent editor behavior,
+cleaner diffs in version control, and easier programmatic manipulation.
+
+### Options
+
+The string 'tab' or an integer indicating the number of spaces to use per tab.
+
+An object may be provided to fine tune the indentation rules:
+
+  * `"SwitchCase"` (default: 0) enforces indentation level for `case` clauses in
+                     `switch` statements
+  * `"VariableDeclarator"` (default: 1) enforces indentation level for `var` declarators;
+                             can also take an object to define separate rules for `var`,
+                             `let` and `const` declarations.
+  * `"outerIIFEBody"` (default: 1) enforces indentation level for file-level IIFEs.
+  * `"MemberExpression"` (off by default) enforces indentation level for multi-line
+                           property chains (except in variable declarations and assignments)
+  * `"FunctionDeclaration"` takes an object to define rules for function declarations.
+      * `"parameters"` (off by default) enforces indentation level for parameters in a
+                         function declaration. This can either be a number indicating
+                         indentation level, or the string `"first"` indicating that all
+                         parameters of the declaration must be aligned with the first parameter.
+      * `"body"` (default: 1) enforces indentation level for the body of a function expression.
+  * `"FunctionExpression"` takes an object to define rules for function declarations.
+      * `"parameters"` (off by default) enforces indentation level for parameters in a
+                         function declaration. This can either be a number indicating
+                         indentation level, or the string `"first"` indicating that all
+                         parameters of the declaration must be aligned with the first parameter.
+      * `"body"` (default: 1) enforces indentation level for the body of a function expression.
+
+### TSLint Rule: `indent`
+
+TSLint provides the [`indent`] rule but it currently only checks if we are using tabs or spaces.
+As of 11/1/2016 there is an open issue to add enhancements to the rule: https://github.com/palantir/tslint/issues/581.
+
+[`indent`]: http://palantir.github.io/tslint/rules/indent

--- a/src/readme/rules.ts
+++ b/src/readme/rules.ts
@@ -1908,23 +1908,35 @@ const rules: IRule[] = [
   {
     available: true,
     eslintRule: 'indent',
-    tslintRule: 'indent',
+    tslintRule: 'ter-indent',
     category: 'Stylistic Issues',
-    description: 'specify tab or space width for your code',
+    description: 'enforce consistent indentation',
     eslintUrl: 'http://eslint.org/docs/rules/indent',
-    tslintUrl: 'http://palantir.github.io/tslint/rules/indent',
-    provider: 'native',
+    provider: 'tslint-eslint-rules',
     usage: `~~~json
     "indent": [
         true,
-        "spaces"
+        "tab"
       ]
     ~~~
-    
+
     ~~~json
     "indent": [
         true,
-        "tabs"
+        2
+      ]
+    ~~~
+
+    ~~~json
+    "indent": [
+        true,
+        2,
+        {
+          "FunctionExpression": {
+            "parameters": 1,
+            "body": 1
+          }
+        }
       ]
     ~~~`
   },

--- a/src/rules/terIndentRule.ts
+++ b/src/rules/terIndentRule.ts
@@ -7,6 +7,7 @@
  */
 import * as ts from 'typescript';
 import * as Lint from 'tslint/lib/lint';
+import * as assign from 'object-assign';
 
 const DEFAULT_VARIABLE_INDENT = 1;
 const DEFAULT_PARAMETER_INDENT = null;
@@ -181,7 +182,7 @@ class IndentWalker extends Lint.RuleWalker {
           const: userOptions.VariableDeclarator
         };
       } else if (typeof userOptions.VariableDeclarator === 'object') {
-        Object.assign(OPTIONS.VariableDeclarator, userOptions.VariableDeclarator);
+        assign(OPTIONS.VariableDeclarator, userOptions.VariableDeclarator);
       }
 
       if (typeof userOptions.outerIIFEBody === 'number') {
@@ -193,11 +194,11 @@ class IndentWalker extends Lint.RuleWalker {
       }
 
       if (typeof userOptions.FunctionDeclaration === 'object') {
-        Object.assign(OPTIONS.FunctionDeclaration, userOptions.FunctionDeclaration);
+        assign(OPTIONS.FunctionDeclaration, userOptions.FunctionDeclaration);
       }
 
       if (typeof userOptions.FunctionExpression === 'object') {
-        Object.assign(OPTIONS.FunctionExpression, userOptions.FunctionExpression);
+        assign(OPTIONS.FunctionExpression, userOptions.FunctionExpression);
       }
     }
     this.srcFile = sourceFile;

--- a/src/rules/terIndentRule.ts
+++ b/src/rules/terIndentRule.ts
@@ -42,7 +42,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     description: 'enforce consistent indentation',
     rationale: Lint.Utils.dedent`
       Using only one of tabs or spaces for indentation leads to more consistent editor behavior,
-      cleaner diffs in version control, and easier programatic manipulation.`,
+      cleaner diffs in version control, and easier programmatic manipulation.`,
     optionsDescription: Lint.Utils.dedent`
       The string 'tab' or an integer indicating the number of spaces to use per tab.
 

--- a/src/rules/terIndentRule.ts
+++ b/src/rules/terIndentRule.ts
@@ -1,0 +1,982 @@
+/**
+ * This rule is a direct port of eslint:
+ *
+ * source file: https://github.com/eslint/eslint/blob/master/lib/rules/indent.js
+ * git commit hash: 332d21383d58fa75bd8d192fe03453f9bcbfe095
+ *
+ */
+import * as ts from 'typescript';
+import * as Lint from 'tslint/lib/lint';
+
+const DEFAULT_VARIABLE_INDENT = 1;
+const DEFAULT_PARAMETER_INDENT = null;
+const DEFAULT_FUNCTION_BODY_INDENT = 1;
+let indentType = 'space';
+let indentSize = 4;
+let OPTIONS: any;
+
+function isKind(node: ts.Node, kind: string) {
+  return node.kind === ts.SyntaxKind[kind];
+}
+
+function isOneOf(node: ts.Node, kinds: string[]) {
+  return kinds.some(kind => node.kind === ts.SyntaxKind[kind]);
+}
+
+export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'ter-indent',
+    description: 'enforce consistent indentation',
+    rationale: Lint.Utils.dedent`
+      Using only one of tabs or spaces for indentation leads to more consistent editor behavior,
+      cleaner diffs in version control, and easier programatic manipulation.`,
+    optionsDescription: Lint.Utils.dedent`
+      The string 'tab' or an integer indicating the number of spaces to use per tab.
+
+      An object may be provided to fine tune the indentation rules:
+            
+        * \`"SwitchCase"\` (default: 0) enforces indentation level for \`case\` clauses in 
+                           \`switch\` statements
+        * \`"VariableDeclarator"\` (default: 1) enforces indentation level for \`var\` declarators;
+                                   can also take an object to define separate rules for \`var\`,
+                                   \`let\` and \`const\` declarations.
+        * \`"outerIIFEBody"\` (default: 1) enforces indentation level for file-level IIFEs.
+        * \`"MemberExpression"\` (off by default) enforces indentation level for multi-line
+                                 property chains (except in variable declarations and assignments)
+        * \`"FunctionDeclaration"\` takes an object to define rules for function declarations.
+            * \`"parameters"\` (off by default) enforces indentation level for parameters in a
+                               function declaration. This can either be a number indicating
+                               indentation level, or the string \`"first"\` indicating that all
+                               parameters of the declaration must be aligned with the first parameter.
+            * \`"body"\` (default: 1) enforces indentation level for the body of a function expression.
+        * \`"FunctionExpression"\` takes an object to define rules for function declarations.
+            * \`"parameters"\` (off by default) enforces indentation level for parameters in a
+                               function declaration. This can either be a number indicating
+                               indentation level, or the string \`"first"\` indicating that all
+                               parameters of the declaration must be aligned with the first parameter.
+            * \`"body"\` (default: 1) enforces indentation level for the body of a function expression.
+      `,
+    options: {
+      type: 'array',
+      items: [{
+        type: 'number',
+        minimum: '0'
+      }, {
+        type: 'string',
+        enum: ['tab']
+      }, {
+        type: 'object',
+        properties: {
+          SwitchCase: {
+            type: 'number',
+            minimum: 0
+          },
+          VariableDeclarator: {
+            type: 'object',
+            properties: {
+              var: {
+                type: 'number',
+                minimum: 0
+              },
+              let: {
+                type: 'number',
+                minimum: 0
+              },
+              const: {
+                type: 'number',
+                minimum: 0
+              }
+            }
+          },
+          outerIIFEBody: {
+            type: 'number'
+          },
+          FunctionDeclaration: {
+            type: 'object',
+            properties: {
+              parameters: {
+                type: 'number',
+                minimum: 0
+              },
+              body: {
+                type: 'number',
+                minimum: 0
+              }
+            }
+          },
+          FunctionExpression: {
+            type: 'object',
+            properties: {
+              parameters: {
+                type: 'number',
+                minimum: 0
+              },
+              body: {
+                type: 'number',
+                minimum: 0
+              }
+            }
+          },
+          MemberExpression: {
+            type: 'number'
+          }
+        },
+        additionalProperties: false
+      }],
+      minLength: 1,
+      maxLength: 2
+    },
+    optionExamples: [
+    ],
+    type: 'maintainability'
+  };
+
+  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    const walker = new IndentWalker(sourceFile, this.getOptions());
+    return this.applyWithWalker(walker);
+  }
+}
+
+class IndentWalker extends Lint.RuleWalker {
+  private srcFile: ts.SourceFile;
+  private srcText: string;
+  private caseIndentStore: { [key: number]: number } = {};
+  private varIndentStore: { [key: number]: number } = {};
+
+  constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
+    super(sourceFile, options);
+    OPTIONS = {
+      SwitchCase: 0,
+      VariableDeclarator: {
+        var: DEFAULT_VARIABLE_INDENT,
+        let: DEFAULT_VARIABLE_INDENT,
+        const: DEFAULT_VARIABLE_INDENT
+      },
+      outerIIFEBody: null,
+      FunctionDeclaration: {
+        parameters: DEFAULT_PARAMETER_INDENT,
+        body: DEFAULT_FUNCTION_BODY_INDENT
+      },
+      FunctionExpression: {
+        parameters: DEFAULT_PARAMETER_INDENT,
+        body: DEFAULT_FUNCTION_BODY_INDENT
+      }
+    };
+    const firstParam = this.getOptions()[0];
+    if (firstParam === 'tab') {
+      indentSize = 1;
+      indentType = 'tab';
+    } else {
+      indentSize = firstParam || 4;
+      indentType = 'space';
+    }
+    const userOptions = this.getOptions()[1];
+    if (userOptions) {
+      OPTIONS.SwitchCase = userOptions.SwitchCase || 0;
+
+      if (typeof userOptions.VariableDeclarator === 'number') {
+        OPTIONS.VariableDeclarator = {
+          var: userOptions.VariableDeclarator,
+          let: userOptions.VariableDeclarator,
+          const: userOptions.VariableDeclarator
+        };
+      } else if (typeof userOptions.VariableDeclarator === 'object') {
+        Object.assign(OPTIONS.VariableDeclarator, userOptions.VariableDeclarator);
+      }
+
+      if (typeof userOptions.outerIIFEBody === 'number') {
+        OPTIONS.outerIIFEBody = userOptions.outerIIFEBody;
+      }
+
+      if (typeof userOptions.MemberExpression === 'number') {
+        OPTIONS.MemberExpression = userOptions.MemberExpression;
+      }
+
+      if (typeof userOptions.FunctionDeclaration === 'object') {
+        Object.assign(OPTIONS.FunctionDeclaration, userOptions.FunctionDeclaration);
+      }
+
+      if (typeof userOptions.FunctionExpression === 'object') {
+        Object.assign(OPTIONS.FunctionExpression, userOptions.FunctionExpression);
+      }
+    }
+    this.srcFile = sourceFile;
+    this.srcText = sourceFile.getFullText();
+  }
+
+  private getSourceSubstr(start: number, end: number) {
+    return this.srcText.substr(start, end - start);
+  }
+
+  private getLineAndCharacter(node: ts.Node, byEndLocation: boolean = false) {
+    const index = byEndLocation ? node.getEnd() : node.getStart();
+    return this.srcFile.getLineAndCharacterOfPosition(index);
+  }
+
+  private getLine(node: ts.Node, byEndLocation: boolean = false) {
+    return this.getLineAndCharacter(node, byEndLocation).line;
+  }
+
+  /**
+   * Creates an error message for a line.
+   *
+   * expectedAmount: The expected amount of indentation characters for this line
+   * actualSpaces: The actual number of indentation spaces that were found on this line
+   * actualTabs: The actual number of indentation tabs that were found on this line
+   */
+  private createErrorMessage(expectedAmount, actualSpaces, actualTabs) {
+    const expectedStatement = `${expectedAmount} ${indentType}${expectedAmount === 1 ? '' : 's'}`;
+    const foundSpacesWord = `space${actualSpaces === 1 ? '' : 's'}`;
+    const foundTabsWord = `tab${actualTabs === 1 ? '' : 's'}`;
+    let foundStatement;
+
+    if (actualSpaces > 0 && actualTabs > 0) {
+      foundStatement = `${actualSpaces} ${foundSpacesWord} and ${actualTabs} ${foundTabsWord}`;
+    } else if (actualSpaces > 0) {
+      // Abbreviate the message if the expected indentation is also spaces.
+      // e.g. 'Expected 4 spaces but found 2' rather than 'Expected 4 spaces but found 2 spaces'
+      foundStatement = indentType === 'space' ? actualSpaces : `${actualSpaces} ${foundSpacesWord}`;
+    } else if (actualTabs > 0) {
+      foundStatement = indentType === 'tab' ? actualTabs : `${actualTabs} ${foundTabsWord}`;
+    } else {
+      foundStatement = '0';
+    }
+
+    return `Expected indentation of ${expectedStatement} but found ${foundStatement}.`;
+  }
+
+  /**
+   * Reports a given indent violation
+   * node: Node violating the indent rule
+   * needed: Expected indentation character count
+   * gottenSpaces: Indentation space count in the actual node/code
+   * gottenTabs: Indentation tab count in the actual node/code
+   */
+  private report(node: ts.Node, needed, gottenSpaces, gottenTabs) {
+    if (gottenSpaces && gottenTabs) {
+      // Don't report lines that have both spaces and tabs to avoid conflicts with rules that
+      // report a mix of tabs and spaces.
+      return;
+    }
+    const msg = this.createErrorMessage(needed, gottenSpaces, gottenTabs);
+    const width = gottenSpaces + gottenTabs;
+    this.addFailure(this.createFailure(node.getStart() - width, width, msg));
+  }
+
+  /**
+   * Checks node is the first in its own start line. By default it looks by start line.
+   * [byEndLocation=false]: Lookup based on start position or end
+   */
+  private isNodeFirstInLine(node: ts.Node, byEndLocation: boolean = false) {
+    const token = byEndLocation ? node.getLastToken() : node.getFirstToken();
+    let pos = token.getStart() - 1;
+    while ([' ', '\t'].indexOf(this.srcText.charAt(pos)) !== -1) {
+      pos -= 1;
+    }
+    return this.srcText.charAt(pos) === '\n';
+  }
+
+  /**
+   * Returns the node's indent. Contains keys `space` and `tab`, representing the indent of each
+   * character. Also contains keys `goodChar` and `badChar`, where `goodChar` is the amount of the
+   * user's desired indentation character, and `badChar` is the amount of the other indentation
+   * character.
+   */
+  private getNodeIndent(node: ts.Node) {
+    if (node === this.getSourceFile()) {
+      return { space: 0, tab: 0, goodChar: 0, badChar: 0 };
+    }
+    if (node.kind === ts.SyntaxKind.SyntaxList) {
+      return this.getNodeIndent(node.parent);
+    }
+
+    const endIndex = node.getStart();
+    let pos = endIndex - 1;
+    while (pos > 0 && this.srcText.charAt(pos) !== '\n') {
+      pos -= 1;
+    }
+    const str = this.getSourceSubstr(pos + 1, endIndex);
+    const whiteSpace = (str.match(/^\s+/) || [''])[0];
+    const indentChars = whiteSpace.split('');
+    const spaces = indentChars.filter(char => char === ' ').length;
+    const tabs = indentChars.filter(char => char === '\t').length;
+
+    let firstInLine = false;
+    const comments = ts.getLeadingCommentRanges(node.getFullText(), 0);
+    if (comments && comments.length) {
+      const offset = node.getFullStart();
+      const lastComment = comments[comments.length - 1];
+      const comment = this.getSourceSubstr(lastComment.pos + offset, lastComment.end + offset);
+      if (comment.indexOf('\n') !== -1) {
+        firstInLine = true;
+      }
+    }
+
+    return {
+      firstInLine: spaces + tabs === str.length || firstInLine,
+      space: spaces,
+      tab: tabs,
+      goodChar: indentType === 'space' ? spaces : tabs,
+      badChar: indentType === 'space' ? tabs : spaces
+    };
+  }
+
+  private checkNodeIndent(node: ts.Node, neededIndent: number) {
+    const actualIndent = this.getNodeIndent(node);
+    if (
+      !isKind(node, 'ArrayLiteralExpression') &&
+      !isKind(node, 'ObjectLiteralExpression') &&
+      (actualIndent.goodChar !== neededIndent || actualIndent.badChar !== 0) &&
+      actualIndent.firstInLine
+    ) {
+      this.report(node, neededIndent, actualIndent.space, actualIndent.tab);
+    }
+
+    if (isKind(node, 'IfStatement')) {
+      const elseStatement = (node as ts.IfStatement).elseStatement;
+      if (elseStatement) {
+        const elseKeyword = node.getChildren().filter(ch => isKind(ch, 'ElseKeyword')).shift();
+        this.checkNodeIndent(elseKeyword, neededIndent);
+        if (!this.isNodeFirstInLine(elseStatement)) {
+          this.checkNodeIndent(elseStatement, neededIndent);
+        }
+      }
+    }
+  }
+
+  private isSingleLineNode(node): boolean {
+    return node.getText().indexOf('\n') === -1;
+  }
+
+  /**
+   * Check indentation for blocks
+   */
+  private blockIndentationCheck(node: ts.Node): void {
+    if (this.isSingleLineNode(node)) {
+      return;
+    }
+
+    const functionLike = ['FunctionExpression', 'FunctionDeclaration', 'ArrowFunction'];
+    if (node.parent && isOneOf(node.parent, functionLike)) {
+      this.checkIndentInFunctionBlock(node);
+      return;
+    }
+
+    let indent;
+    let nodesToCheck = [];
+
+    /* For these statements we should check indent from statement beginning, not from the beginning
+       of the block.
+     */
+    const statementsWithProperties = [
+      'IfStatement',
+      'WhileStatement',
+      'ForStatement',
+      'ForInStatement',
+      'ForOfStatement',
+      'DoStatement',
+      'ClassDeclaration',
+      'ClassExpression',
+      'SourceFile'
+    ];
+    if (node.parent && isOneOf(node.parent, statementsWithProperties) && this.isNodeBodyBlock(node)) {
+      indent = this.getNodeIndent(node.parent).goodChar;
+    } else {
+      indent = this.getNodeIndent(node).goodChar;
+    }
+
+    if (isKind(node, 'IfStatement') && !isKind(node['thenStatement'], 'Block')) {
+      nodesToCheck = [node['thenStatement']];
+    } else {
+      if (node.kind === ts.SyntaxKind.Block) {
+        nodesToCheck = node.getChildren()[1].getChildren();
+      } else if (isOneOf(node.parent, ['ClassDeclaration', 'ClassExpression'])) {
+        nodesToCheck = node.getChildren();
+      } else {
+        nodesToCheck = [(node as ts.IterationStatement).statement];
+      }
+    }
+    this.checkNodeIndent(node, indent);
+
+    if (nodesToCheck.length > 0) {
+      this.checkNodesIndent(nodesToCheck, indent + indentSize);
+    }
+
+    if (isKind(node, 'Block')) {
+      this.checkLastNodeLineIndent(node, indent);
+    }
+  }
+
+  private isClassLike(node) {
+    return isOneOf(node, ['ClassDeclaration', 'ClassExpression']);
+  }
+
+  /**
+   * Check if node is an assignment expression, i.e. the binary expression contains the equal token.
+   */
+  private isAssignment(node: ts.Node): boolean {
+    if (!isKind(node, 'BinaryExpression')) {
+      return false;
+    }
+    return (node as ts.BinaryExpression).operatorToken.getText() === '=';
+  }
+
+  /**
+   * Check if the node or node body is a BlockStatement or not
+   */
+  private isNodeBodyBlock(node): boolean {
+    return node.kind === ts.SyntaxKind.Block ||
+      (node.kind === ts.SyntaxKind.SyntaxList && this.isClassLike(node.parent.kind));
+    // return node.type === "BlockStatement" || node.type === "ClassBody" || (node.body && node.body.type === "BlockStatement") ||
+    //   (node.consequent && node.consequent.type === "BlockStatement");
+  }
+
+  /**
+   * Check that the start of the node has the correct level of indentation.
+   */
+  private checkFirstNodeLineIndent(node, firstLineIndent): void {
+    const startIndent = this.getNodeIndent(node);
+    const firstInLine = startIndent.firstInLine;
+    if (firstInLine && (startIndent.goodChar !== firstLineIndent || startIndent.badChar !== 0)) {
+      this.report(node, firstLineIndent, startIndent.space, startIndent.tab);
+    }
+  }
+
+  /**
+   * Check last line of the node has the correct level of indentation.
+   */
+  private checkLastNodeLineIndent(node, lastLineIndent) {
+    const lastToken = node.getLastToken();
+    const endIndent = this.getNodeIndent(lastToken);
+    const firstInLine = endIndent.firstInLine;
+    if (firstInLine && (endIndent.goodChar !== lastLineIndent || endIndent.badChar !== 0)) {
+      this.report(lastToken, lastLineIndent, endIndent.space, endIndent.tab);
+    }
+  }
+
+  /**
+   * Check to see if the node function is a file level IIFE
+   */
+  private isOuterIIFE(node): boolean {
+    let parent = node.parent;
+    let expressionIsNode = parent.expression !== node;
+    if (isKind(parent, 'ParenthesizedExpression')) {
+      parent = parent.parent;
+    }
+    let stmt = parent.parent;
+
+    // Verify that the node is an IIEF
+    if (!isKind(parent, 'CallExpression') || expressionIsNode) {
+      return false;
+    }
+
+    // Navigate legal ancestors to determine whether this IIEF is outer
+    while (
+      isKind(stmt, 'PrefixUnaryExpression') && (
+        stmt.operator === ts.SyntaxKind.ExclamationToken ||
+        stmt.operator === ts.SyntaxKind.TildeToken ||
+        stmt.operator === ts.SyntaxKind.PlusToken ||
+        stmt.operator === ts.SyntaxKind.MinusToken
+      ) ||
+      isKind(stmt, 'BinaryExpression') ||
+      isKind(stmt, 'SyntaxList') ||
+      isKind(stmt, 'VariableDeclaration') ||
+      isKind(stmt, 'VariableDeclarationList') ||
+      isKind(stmt, 'ParenthesizedExpression')
+    ) {
+      stmt = stmt.parent;
+    }
+
+    return ((
+      isKind(stmt, 'ExpressionStatement') ||
+      isKind(stmt, 'VariableStatement')) &&
+      stmt.parent && isKind(stmt.parent, 'SourceFile')
+    );
+  }
+
+  /**
+   * Check to see if the argument before the callee node is multi-line and
+   * there should only be 1 argument before the callee node
+   */
+  private isArgBeforeCalleeNodeMultiline(node: ts.Node): boolean {
+    const parent = node.parent;
+    if (parent['arguments'].length >= 2 && parent['arguments'][1] === node) {
+      const firstArg = parent['arguments'][0];
+      return this.getLine(firstArg, true) > this.getLine(firstArg);
+    }
+
+    return false;
+  }
+
+  /**
+   * Check indent for function block content
+   */
+  private checkIndentInFunctionBlock(node): void {
+    const calleeNode = node.parent; // FunctionExpression
+    let indent = this.getNodeIndent(calleeNode).goodChar;
+
+    if (calleeNode.parent.kind === ts.SyntaxKind.CallExpression) {
+      const calleeParent = calleeNode.parent;
+
+      if (calleeNode.kind !== ts.SyntaxKind.FunctionExpression && calleeNode.kind !== ts.SyntaxKind.ArrowFunction) {
+        if (calleeParent && this.getLine(calleeParent) < this.getLine(node)) {
+          indent = this.getNodeIndent(calleeParent).goodChar;
+        }
+      } else {
+        const callee = calleeParent.expression;
+        if (
+          this.isArgBeforeCalleeNodeMultiline(calleeNode) &&
+          this.getLine(callee) === this.getLine(callee, true) &&
+          !this.isNodeFirstInLine(calleeNode)
+        ) {
+          indent = this.getNodeIndent(calleeParent).goodChar;
+        }
+      }
+    }
+    // function body indent should be indent + indent size, unless this
+    // is a FunctionDeclaration, FunctionExpression, or outer IIFE and the corresponding options are enabled.
+    let functionOffset = indentSize;
+    if (OPTIONS.outerIIFEBody !== null && this.isOuterIIFE(calleeNode)) {
+      functionOffset = OPTIONS.outerIIFEBody * indentSize;
+    } else if (calleeNode.kind === ts.SyntaxKind.FunctionExpression) {
+      functionOffset = OPTIONS.FunctionExpression.body * indentSize;
+    } else if (calleeNode.kind === ts.SyntaxKind.FunctionDeclaration) {
+      functionOffset = OPTIONS.FunctionDeclaration.body * indentSize;
+    }
+    indent += functionOffset;
+
+    // check if the node is inside a variable
+    const parentVarNode = this.getVariableDeclaratorNode(node);
+
+    if (parentVarNode && this.isNodeInVarOnTop(node, parentVarNode)) {
+      const varKind = parentVarNode.parent.getFirstToken().getText();
+      indent += indentSize * OPTIONS.VariableDeclarator[varKind];
+    }
+
+    if (node.statements.length) {
+      this.checkNodesIndent(node.statements, indent);
+    }
+
+    this.checkLastNodeLineIndent(node, indent - functionOffset);
+  }
+
+  /**
+   * Check indent for nodes list.
+   */
+  protected checkNodesIndent(nodes: ts.Node[], indent: number): void {
+    nodes.forEach(node => this.checkNodeIndent(node, indent));
+  }
+
+  /**
+   * Returns the expected indentation for the case statement.
+   */
+  private expectedCaseIndent(node: ts.Node, switchIndent?: number) {
+    const switchNode = (node.kind === ts.SyntaxKind.SwitchStatement) ? node : node.parent;
+    const line = this.getLine(switchNode);
+    let caseIndent;
+
+    if (this.caseIndentStore[line]) {
+      return this.caseIndentStore[line];
+    } else {
+      if (typeof switchIndent === 'undefined') {
+        switchIndent = this.getNodeIndent(switchNode).goodChar;
+      }
+
+      caseIndent = switchIndent + (indentSize * OPTIONS.SwitchCase);
+      this.caseIndentStore[line] = caseIndent;
+      return caseIndent;
+    }
+  }
+
+  /**
+   * Returns the expected indentation for the variable declarations.
+   */
+  private expectedVarIndent(node: ts.VariableDeclaration, varIndent?: number) {
+    // VariableStatement -> VariableDeclarationList -> VariableDeclaration
+    const varNode = node.parent.parent;
+    const line = this.getLine(varNode);
+    let indent;
+
+    if (this.varIndentStore[line]) {
+      return this.varIndentStore[line];
+    } else {
+      if (typeof varIndent === 'undefined') {
+        varIndent = this.getNodeIndent(varNode).goodChar;
+      }
+      const varKind = varNode.getFirstToken().getText();
+      indent = varIndent + (indentSize * OPTIONS.VariableDeclarator[varKind]);
+      this.varIndentStore[line] = indent;
+      return indent;
+    }
+  }
+
+  /**
+   * Returns a parent node of given node based on a specified type
+   * if not present then return null
+   */
+  private getParentNodeByType<T extends ts.Node>(node: ts.Node, kind): T {
+    let parent = node.parent;
+
+    while (parent.kind !== kind && parent.kind !== ts.SyntaxKind.SourceFile) {
+      parent = parent.parent;
+    }
+
+    return parent.kind === kind ? parent as T : null;
+  }
+
+  /**
+   * Returns the VariableDeclarator based on the current node if not present then return null.
+   */
+  protected getVariableDeclaratorNode(node: ts.Node): ts.VariableDeclaration {
+    return this.getParentNodeByType<ts.VariableDeclaration>(node, ts.SyntaxKind.VariableDeclaration);
+  }
+
+  /**
+   * Returns the BinaryExpression based on the current node if not present then return null.
+   */
+  protected getBinaryExpressionNode(node: ts.Node): ts.BinaryExpression {
+    return this.getParentNodeByType<ts.BinaryExpression>(node, ts.SyntaxKind.BinaryExpression);
+  }
+
+  /**
+   * Check indent for array block content or object block content
+   */
+  protected checkIndentInArrayOrObjectBlock(node: ts.Node): void {
+    if (this.isSingleLineNode(node)) {
+      return;
+    }
+
+    let elements = isKind(node, 'ObjectLiteralExpression') ? node['properties'] : node['elements'];
+
+    // filter out empty elements, an example would be [ , 2]
+    elements = elements.filter((elem) => {
+      return elem.getText() !== '';
+    });
+
+    // Skip if first element is in same line with this node
+    if (elements.length && this.getLine(elements[0]) === this.getLine(node)) {
+      return;
+    }
+
+    const nodeLine = this.getLine(node);
+    const nodeEndLine = this.getLine(node, true);
+
+    // Skip if first element is in same line with this node
+    if (elements.length) {
+      const firstElementLine = this.getLine(elements[0]);
+      if (nodeLine === firstElementLine) {
+        return;
+      }
+    }
+
+    let nodeIndent;
+    let elementsIndent;
+    let varKind;
+    const parentVarNode = this.getVariableDeclaratorNode(node);
+
+    if (this.isNodeFirstInLine(node)) {
+      const parent = node.parent;
+      let effectiveParent = parent;
+
+      if (parent.kind === ts.SyntaxKind.PropertyDeclaration) {
+        if (this.isNodeFirstInLine(parent)) {
+          effectiveParent = parent.parent.parent;
+        } else {
+          effectiveParent = parent.parent;
+        }
+      }
+
+      nodeIndent = this.getNodeIndent(effectiveParent).goodChar;
+      if (parentVarNode && this.getLine(parentVarNode) !== nodeLine) {
+        if (!isKind(parent, 'VariableDeclaration') || parentVarNode === parentVarNode.parent.declarations[0]) {
+          const parentVarLine = this.getLine(parentVarNode);
+          const effectiveParentLine = this.getLine(effectiveParent);
+          if (isKind(parent, 'VariableDeclaration') && parentVarLine === effectiveParentLine) {
+            varKind = parentVarNode.parent.getFirstToken().getText();
+            nodeIndent = nodeIndent + (indentSize * OPTIONS.VariableDeclarator[varKind]);
+          } else if (
+            isOneOf(parent, [
+              'ObjectLiteralExpression',
+              'ArrayLiteralExpression',
+              'CallExpression',
+              'ArrowFunction',
+              'NewExpression',
+              'BinaryExpression'
+            ])
+          ) {
+            nodeIndent = nodeIndent + indentSize;
+          }
+        }
+      } else if (
+        !parentVarNode &&
+        !this.isFirstArrayElementOnSameLine(parent) &&
+        effectiveParent.kind !== ts.SyntaxKind.PropertyAccessExpression &&
+        effectiveParent.kind !== ts.SyntaxKind.ExpressionStatement &&
+        effectiveParent.kind !== ts.SyntaxKind.PropertyAssignment &&
+        !(this.isAssignment(effectiveParent))
+      ) {
+        nodeIndent = nodeIndent + indentSize;
+      }
+
+      elementsIndent = nodeIndent + indentSize;
+      this.checkFirstNodeLineIndent(node, nodeIndent);
+    } else {
+      nodeIndent = this.getNodeIndent(node).goodChar;
+      elementsIndent = nodeIndent + indentSize;
+    }
+
+    /*
+       * Check if the node is a multiple variable declaration; if so, then
+       * make sure indentation takes that into account.
+       */
+    if (parentVarNode && this.isNodeInVarOnTop(node, parentVarNode)) {
+      varKind = parentVarNode.parent.getFirstToken().getText();
+      elementsIndent += indentSize * OPTIONS.VariableDeclarator[varKind];
+    }
+
+    this.checkNodesIndent(elements, elementsIndent);
+
+    if (elements.length > 0) {
+      const lastLine = this.getLine(elements[elements.length - 1], true);
+      // Skip last block line check if last item in same line
+      if (lastLine === nodeEndLine) {
+        return;
+      }
+    }
+
+    this.checkLastNodeLineIndent(node, elementsIndent - indentSize);
+  }
+
+  /**
+   * Check to see if the first element inside an array is an object and on the same line as the node
+   */
+  private isFirstArrayElementOnSameLine(node: ts.Node): boolean {
+    if (isKind(node, 'ArrayLiteralExpression')) {
+      const ele = (node as ts.ArrayLiteralExpression).elements[0];
+      if (ele) {
+        return isKind(ele, 'ObjectLiteralExpression') && this.getLine(ele) === this.getLine(node);
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Check to see if the node is part of the multi-line variable declaration.
+   * Also if its on the same line as the varNode
+   * @param {ASTNode} node node to check
+   * @param {ASTNode} varNode variable declaration node to check against
+   * @returns {boolean} True if all the above condition satisfy
+   */
+  protected isNodeInVarOnTop(node: ts.Node, varNode) {
+    const nodeLine = this.getLine(node);
+    const parentLine = this.getLine(varNode.parent);
+    return varNode &&
+      parentLine === nodeLine &&
+      varNode.parent.declarations.length > 1;
+  }
+
+  /**
+   * Check and decide whether to check for indentation for blockless nodes
+   * Scenarios are for or while statements without braces around them
+   */
+  private blockLessNodes(node) {
+    if (!isKind(node.statement, 'Block')) {
+      this.blockIndentationCheck(node);
+    }
+  }
+
+  /**
+   * Check indentation for variable declarations
+   */
+  private checkIndentInVariableDeclarations(node: ts.VariableDeclaration) {
+    const indent = this.expectedVarIndent(node);
+    this.checkNodeIndent(node, indent);
+  }
+
+  /**
+   * Check indentation for case and default clauses in switch statements.
+   */
+  private visitCase(node: ts.CaseClause | ts.DefaultClause) {
+    if (this.isSingleLineNode(node)) {
+      return;
+    }
+    const caseIndent = this.expectedCaseIndent(node);
+    this.checkNodesIndent(node.statements, caseIndent + indentSize);
+  }
+
+  protected visitClassDeclaration(node: ts.ClassDeclaration) {
+    const len = node.getChildCount();
+    this.blockIndentationCheck(node.getChildAt(len - 2));
+    super.visitClassDeclaration(node);
+  }
+
+  protected visitClassExpression(node: ts.ClassExpression) {
+    const len = node.getChildCount();
+    this.blockIndentationCheck(node.getChildAt(len - 2));
+    super.visitClassExpression(node);
+  }
+
+  protected visitBlock(node: ts.Block) {
+    this.blockIndentationCheck(node);
+    super.visitBlock(node);
+  }
+
+  protected visitIfStatement(node: ts.IfStatement) {
+    const thenLine = this.getLine(node.thenStatement);
+    const line = this.getLine(node);
+    if (node.thenStatement.kind !== ts.SyntaxKind.Block && thenLine > line) {
+      this.blockIndentationCheck(node);
+    }
+    super.visitIfStatement(node);
+  }
+
+  protected visitObjectLiteralExpression(node: ts.ObjectLiteralExpression) {
+    this.checkIndentInArrayOrObjectBlock(node);
+    super.visitObjectLiteralExpression(node);
+  }
+
+  protected visitArrayLiteralExpression(node: ts.ArrayLiteralExpression) {
+    this.checkIndentInArrayOrObjectBlock(node);
+    super.visitArrayLiteralExpression(node);
+  }
+
+  protected visitSwitchStatement(node: ts.SwitchStatement) {
+    const switchIndent = this.getNodeIndent(node).goodChar;
+    const caseIndent = this.expectedCaseIndent(node, switchIndent);
+    this.checkNodesIndent(node.caseBlock.clauses, caseIndent);
+    this.checkLastNodeLineIndent(node, switchIndent);
+    super.visitSwitchStatement(node);
+  }
+
+  protected visitCaseClause(node: ts.CaseClause) {
+    this.visitCase(node);
+    super.visitCaseClause(node);
+  }
+
+  protected visitDefaultClause(node: ts.DefaultClause) {
+    this.visitCase(node);
+    super.visitDefaultClause(node);
+  }
+
+  protected visitWhileStatement(node: ts.WhileStatement) {
+    this.blockLessNodes(node);
+    super.visitWhileStatement(node);
+  }
+
+  protected visitForStatement(node: ts.ForStatement) {
+    this.blockLessNodes(node);
+    super.visitForStatement(node);
+  }
+
+  protected visitForInStatement(node: ts.ForInStatement) {
+    this.blockLessNodes(node);
+    super.visitForInStatement(node);
+  }
+
+  protected visitDoStatement(node: ts.DoStatement) {
+    this.blockLessNodes(node);
+    super.visitDoStatement(node);
+  }
+
+  protected visitVariableDeclaration(node: ts.VariableDeclaration) {
+    this.checkIndentInVariableDeclarations(node);
+    super.visitVariableDeclaration(node);
+  }
+
+  protected visitVariableStatement(node: ts.VariableStatement) {
+    super.visitVariableStatement(node);
+
+    // VariableStatement -> VariableDeclarationList -> (VarKeyword, SyntaxList)
+    const list = node.getChildAt(0).getChildAt(1);
+    if (!list) {
+      return;
+    }
+    const len = list.getChildCount();
+    const lastElement = list.getChildAt(len - 1);
+    const lastToken = node.getLastToken();
+    const lastTokenLine = this.getLine(lastToken, true);
+    const lastElementLine = this.getLine(lastElement, true);
+
+    // Only check the last line if there is any token after the last item
+    if (lastTokenLine <= lastElementLine) {
+      return;
+    }
+
+    const tokenBeforeLastElement = list.getChildAt(len - 2);
+    if (isKind(tokenBeforeLastElement, 'CommaToken')) {
+      // Special case for comma-first syntax where the semicolon is indented
+      this.checkLastNodeLineIndent(node, this.getNodeIndent(tokenBeforeLastElement).goodChar);
+    } else {
+      // TODO: Do we ever get here? Did not see an error in the test when uncommenting next line.
+      // this.checkLastNodeLineIndent(node, elementsIndent - indentSize);
+    }
+  }
+
+  protected visitFunctionDeclaration(node: ts.FunctionDeclaration) {
+    if (this.isSingleLineNode(node)) {
+      return;
+    }
+    if (OPTIONS.FunctionDeclaration.parameters === 'first' && node.parameters.length) {
+      const indent = this.getLineAndCharacter(node.parameters[0]).character;
+      this.checkNodesIndent(node.parameters.slice(1), indent);
+    } else if (OPTIONS.FunctionDeclaration.parameters !== null) {
+      this.checkNodesIndent(
+        node.parameters,
+        this.getNodeIndent(node).goodChar + indentSize * OPTIONS.FunctionDeclaration.parameters
+      );
+    }
+
+    super.visitFunctionDeclaration(node);
+  }
+
+  protected visitFunctionExpression(node: ts.FunctionExpression) {
+    if (this.isSingleLineNode(node)) {
+      return;
+    }
+    if (OPTIONS.FunctionExpression.parameters === 'first' && node.parameters.length) {
+      const indent = this.getLineAndCharacter(node.parameters[0]).character;
+      this.checkNodesIndent(node.parameters.slice(1), indent);
+    } else if (OPTIONS.FunctionExpression.parameters !== null) {
+      this.checkNodesIndent(
+        node.parameters,
+        this.getNodeIndent(node).goodChar + indentSize * OPTIONS.FunctionExpression.parameters
+      );
+    }
+    super.visitFunctionExpression(node);
+  }
+
+  protected visitPropertyAccessExpression(node: ts.PropertyAccessExpression) {
+    if (typeof OPTIONS.MemberExpression === 'undefined') {
+      return;
+    }
+
+    if (this.isSingleLineNode(node)) {
+      return;
+    }
+
+    // The typical layout of variable declarations and assignments
+    // alter the expectation of correct indentation. Skip them.
+    // TODO: Add appropriate configuration options for variable
+    // declarations and assignments.
+    if (this.getVariableDeclaratorNode(node)) {
+      return;
+    }
+
+    const binaryNode: ts.BinaryExpression = this.getBinaryExpressionNode(node);
+    if (binaryNode && this.isAssignment(binaryNode)) {
+      return;
+    }
+
+    const propertyIndent = this.getNodeIndent(node).goodChar + indentSize * OPTIONS.MemberExpression;
+    const checkNodes = [node.name, node.dotToken];
+
+    this.checkNodesIndent(checkNodes, propertyIndent);
+    super.visitPropertyAccessExpression(node);
+  }
+
+  protected visitSourceFile(node: ts.SourceFile) {
+    // Root nodes should have no indent
+    this.checkNodesIndent(node.statements, 0);
+    super.visitSourceFile(node);
+  }
+}

--- a/src/rules/terIndentRule.ts
+++ b/src/rules/terIndentRule.ts
@@ -7,7 +7,6 @@
  */
 import * as ts from 'typescript';
 import * as Lint from 'tslint/lib/lint';
-import * as assign from 'object-assign';
 
 const DEFAULT_VARIABLE_INDENT = 1;
 const DEFAULT_PARAMETER_INDENT = null;
@@ -15,6 +14,19 @@ const DEFAULT_FUNCTION_BODY_INDENT = 1;
 let indentType = 'space';
 let indentSize = 4;
 let OPTIONS: any;
+
+function assign(target: any, ...sources: any[]): any {
+  sources.forEach((source) => {
+    if (source !== undefined && source !== null) {
+      for (const nextKey in source) {
+        if (source.hasOwnProperty(nextKey)) {
+          target[nextKey] = source[nextKey];
+        }
+      }
+    }
+  });
+  return target;
+}
 
 function isKind(node: ts.Node, kind: string) {
   return node.kind === ts.SyntaxKind[kind];

--- a/src/rules/terIndentRule.ts
+++ b/src/rules/terIndentRule.ts
@@ -358,7 +358,11 @@ class IndentWalker extends Lint.RuleWalker {
   }
 
   private isSingleLineNode(node): boolean {
-    return node.getText().indexOf('\n') === -1;
+    // Note: all the tests would pass using `node.getFullText()` but we should only use this for
+    // the syntax list nodes, otherwise nodes which are single line may say they are multiline
+    // and this will make us do unnecessary checks.
+    const text = node.kind === ts.SyntaxKind.SyntaxList ? node.getFullText() : node.getText();
+    return text.indexOf('\n') === -1;
   }
 
   /**

--- a/src/rules/terIndentRule.ts
+++ b/src/rules/terIndentRule.ts
@@ -968,7 +968,11 @@ class IndentWalker extends Lint.RuleWalker {
     }
 
     const propertyIndent = this.getNodeIndent(node).goodChar + indentSize * OPTIONS.MemberExpression;
-    const checkNodes = [node.name, node.dotToken];
+
+    // Assuming that the node has three children: [expression, dotToken, name]
+    // In typescript < 2.0 we had access to the dotToken as an attribute of the node.
+    const dotToken = node.getChildAt(1);
+    const checkNodes = [node.name, dotToken];
 
     this.checkNodesIndent(checkNodes, propertyIndent);
     super.visitPropertyAccessExpression(node);

--- a/src/test/fixtures/indent-invalid.txt
+++ b/src/test/fixtures/indent-invalid.txt
@@ -1,0 +1,530 @@
+if (a) {
+  var b = c;
+  var d = e
+    * f;
+    var e = f; // <-
+// NO ERROR: DON'T VALIDATE EMPTY OR COMMENT ONLY LINES
+  function g() {
+    if (h) {
+      var i = j;
+      } // <-
+    } // <-
+
+  while (k) l++;
+  while (m) {
+  n--; // ->
+    } // <-
+
+  do {
+    o = p +
+  q; // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+    o = p +
+    q;
+    } while(r); // <-
+
+  for (var s in t) {
+    u++;
+  }
+
+    for (;;) { // <- Fix this when issue #3737 gets resolved
+      v++; // <-
+  }
+
+  if ( w ) {
+    x++;
+  } else if (y) {
+      z++; // <-
+    aa++;
+    } else { // <-
+  bb++; // ->
+} // ->
+}
+
+/**/var b; // NO ERROR: single line multi-line comments followed by code is OK
+/*
+ *
+ */ var b; // ERROR: multi-line comments followed by code is not OK
+
+var arr = [
+  a,
+  b,
+  c,
+  function (){
+    d
+    }, // <-
+  {},
+  {
+    a: b,
+    c: d,
+    d: e
+  },
+  [
+    f,
+    g,
+    h,
+    i
+  ],
+  [j]
+];
+
+var obj = {
+  a: {
+    b: {
+      c: d,
+      e: f,
+      g: h +
+    i // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+    }
+  },
+  g: [
+    h,
+    i,
+    j,
+    k
+  ]
+};
+
+var arrObject = {a:[
+  a,
+  b, // NO ERROR: INDENT ONCE WHEN MULTIPLE INDENTED EXPRESSIONS ARE ON SAME LINE
+  c
+]};
+
+var objArray = [{
+  a: b,
+  b: c, // NO ERROR: INDENT ONCE WHEN MULTIPLE INDENTED EXPRESSIONS ARE ON SAME LINE
+  c: d
+}];
+
+var arrArray = [[
+  a,
+  b, // NO ERROR: INDENT ONCE WHEN MULTIPLE INDENTED EXPRESSIONS ARE ON SAME LINE
+  c
+]];
+
+var objObject = {a:{
+  a: b,
+  b: c, // NO ERROR: INDENT ONCE WHEN MULTIPLE INDENTED EXPRESSIONS ARE ON SAME LINE
+  c: d
+}};
+
+
+switch (a) {
+  case 'a':
+  var a = 'b'; // ->
+    break;
+  case 'b':
+    var a = 'b';
+    break;
+  case 'c':
+      var a = 'b'; // <-
+    break;
+  case 'd':
+    var a = 'b';
+  break; // ->
+  case 'f':
+    var a = 'b';
+    break;
+  case 'g':     {
+    var a = 'b';
+    break;
+  }
+  case 'z':
+  default:
+      break; // <-
+}
+
+a.b('hi')
+   .c(a.b()) // <-
+   .d(); // <-
+
+if ( a ) {
+  if ( b ) {
+d.e(f) // ->
+  .g() // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+  .h(); // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+
+    i.j(m)
+      .k() // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+      .l(); // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+
+      n.o(p) // <-
+        .q() // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+        .r(); // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+  }
+}
+
+var a = b,
+  c = function () {
+  h = i; // ->
+    j = k;
+      l = m; // <-
+  },
+  e = {
+    f: g,
+    n: o,
+    p: q
+  },
+  r = [
+    s,
+    t,
+    u
+  ];
+
+var a = function () {
+b = c; // ->
+  d = e;
+    f = g; // <-
+};
+
+function c(a, b) {
+  if (a || (a &&
+            b)) { // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+    return d;
+  }
+}
+
+if ( a
+  || b ) {
+var x; // ->
+  var c,
+    d = function(a,
+                  b) {
+    a; // ->
+      b;
+        c; // <-
+    }
+}
+
+
+a({
+  d: 1
+});
+
+a(
+1
+);
+
+a(
+  b({
+    d: 1
+  })
+);
+
+a(
+  b(
+    c({
+      d: 1,
+      e: 1,
+      f: 1
+    })
+  )
+);
+
+a({ d: 1 });
+
+aa(
+   b({ // NO ERROR: aligned with previous opening paren
+     c: d,
+     e: f,
+     f: g
+   })
+);
+
+aaaaaa(
+  b,
+  c,
+  {
+    d: a
+  }
+);
+
+a(b, c,
+  d, e,
+    f, g  // NO ERROR: alignment of arguments of callExpression not checked
+  );  // NO ERROR: this has nothing to do with indentation, this is CallExpression spacing
+
+a(
+  ); // NO ERROR: this has nothing to do with indentation, this is CallExpression spacing
+
+aaaaaa(
+  b,
+  c, {
+    d: a
+  }, {
+    e: f
+  }
+);
+
+a.b()
+  .c(function(){
+    var a;
+  }).d.e;
+
+if (a == 'b') {
+  if (c && d) e = f
+  else g('h').i('j')
+}
+
+a = function (b, c) {
+  return a(function () {
+    var d = e
+    var f = g
+    var h = i
+
+    if (!j) k('l', (m = n))
+    if (o) p
+    else if (q) r
+  })
+}
+
+var a = function() {
+  "b"
+    .replace(/a/, "a")
+    .replace(/bc?/, function(e) {
+      return "b" + (e.f === 2 ? "c" : "f");
+    })
+    .replace(/d/, "d");
+};
+
+$(b)
+  .on('a', 'b', function() { $(c).e('f'); })
+  .on('g', 'h', function() { $(i).j('k'); });
+
+a
+  .b('c',
+           'd'); // NO ERROR: this has nothing to do with indentation, this is CallExpression spacing
+
+a
+  .b('c', [ 'd', function(e) {
+    e++;
+  }]);
+
+var a = function() {
+      a++;
+    b++; // <-
+        c++; // <-
+    },
+    b;
+
+var b = [
+      a,
+      b,
+      c
+    ],
+    c;
+
+var c = {
+      a: 1,
+      b: 2,
+      c: 3
+    },
+    d;
+
+// holes in arrays indentation
+x = [
+ 1,
+ 1,
+ 1,
+ 1,
+ 1,
+ 1,
+ 1,
+ 1,
+ 1,
+ 1
+];
+
+try {
+  a++;
+    b++; // <-
+c++; // ->
+} catch (d) {
+  e++;
+    f++; // <-
+g++; // ->
+} finally {
+  h++;
+    i++; // <-
+j++; // ->
+}
+
+if (array.some(function(){
+  return true;
+})) {
+a++; // ->
+  b++;
+    c++; // <-
+}
+
+var a = b.c(function() {
+      d++;
+    }),
+    e;
+
+switch (true) {
+  case (a
+  && b):
+case (c // ->
+&& d):
+    case (e // <-
+    && f):
+  case (g
+&& h):
+      var i = j; // <-
+    var k = l;
+  var m = n; // ->
+}
+
+if (a) {
+  b();
+}
+else {
+c(); // ->
+  d();
+    e(); // <-
+}
+
+if (a) b();
+else {
+c(); // ->
+  d();
+    e(); // <-
+}
+
+if (a) {
+  b();
+} else c();
+
+if (a) {
+  b();
+}
+else c();
+
+a();
+
+if( "very very long multi line" +
+      "with weird indentation" ) {
+  b();
+a(); // ->
+    c(); // <-
+}
+
+a( "very very long multi line" +
+    "with weird indentation", function() {
+  b();
+a(); // ->
+    c(); // <-
+});
+
+a = function(content, dom) {
+  b();
+    c(); // <-
+d(); // ->
+};
+
+a = function(content, dom) {
+      b();
+        c(); // <-
+    d(); // ->
+    };
+
+a = function(content, dom) {
+    b(); // ->
+    };
+
+a = function(content, dom) {
+b(); // ->
+    };
+
+a('This is a terribly long description youll ' +
+  'have to read', function () {
+  b();
+  c();
+});
+
+if (
+  array.some(function(){
+    return true;
+  })
+) {
+a++; // ->
+  b++;
+    c++; // <-
+}
+
+function c(d) {
+  return {
+    e: function(f, g) {
+    }
+  };
+}
+
+function a(b) {
+  switch(x) {
+    case 1:
+      if (foo) {
+        return 5;
+      }
+  }
+}
+
+function a(b) {
+  switch(x) {
+    case 1:
+      c;
+  }
+}
+
+function a(b) {
+  switch(x) {
+    case 1: c;
+  }
+}
+
+function test() {
+  var a = 1;
+  {
+    a();
+  }
+}
+
+{
+  a();
+}
+
+function a(b) {
+  switch(x) {
+    case 1:
+        {
+        a();
+      }
+      break;
+    default:
+      {
+        b();
+        }
+  }
+}
+
+switch (a) {
+  default:
+    if (b)
+      c();
+}
+
+function test(x) {
+  switch (x) {
+    case 1:
+      return function() {
+        var a = 5;
+        return a;
+      };
+  }
+}
+
+switch (a) {
+  default:
+    if (b)
+      c();
+}

--- a/src/test/rules/helper.ts
+++ b/src/test/rules/helper.ts
@@ -4,6 +4,7 @@ import * as Lint from 'tslint/lib/lint';
 
 export interface IScriptError {
   message: string;
+  line?: number;
 }
 export interface IScript {
   code: string;
@@ -11,6 +12,10 @@ export interface IScript {
   errors?: IScriptError[];
 }
 export type IScripts = (IScript|string)[];
+
+function arrayDiff(source, target) {
+  return source.filter(item => target.indexOf(item) === -1);
+}
 
 export function testScript(rule: string, scriptText: string, config: Object): boolean {
   const options: Lint.ILinterOptions = {
@@ -55,9 +60,13 @@ export function runScript(rule: string, scriptText: string, config: Object, erro
   const result = linter.lint();
 
   const failures = JSON.parse(result.output);
+  const line = errors[0] ? 'line' in errors[0] : false;
 
   if (failures.length !== errors.length) {
-    const errorMsgs = failures.map(x => `- ${x.failure}\n`).join('     ');
+    const errorMsgs = failures.map((x) => {
+      const start = `(${x.startPosition.line})`;
+      return `${start} ${x.failure}\n`;
+    });
     const msg = `Expected ${errors.length} error(s) in:
 
      -------
@@ -66,12 +75,20 @@ export function runScript(rule: string, scriptText: string, config: Object, erro
 
      Found ${failures.length} errors(s):
 
-     ${errorMsgs}
+       ${errorMsgs.join('       ')}
     `;
     assert.fail(failures.length, errors.length, msg);
   } else {
-    const expectedErrorMsgs = errors.map(x => `- ${x.message}\n`).join('       ');
-    const actualErrorMsgs = failures.map(x => `- ${x.failure}\n`).join('       ');
+    const expectedErrorMsgs = errors.map((x) => {
+      const start = line ? `(${x.line})` : '-';
+      return `${start} ${x.message}\n`;
+    });
+    const actualErrorMsgs = failures.map((x) => {
+      const start = line ? `(${x.startPosition.line})` : '-';
+      return `${start} ${x.failure}\n`;
+    });
+    const expected = arrayDiff(expectedErrorMsgs, actualErrorMsgs);
+    const found = arrayDiff(actualErrorMsgs, expectedErrorMsgs);
     const msg = `Error mismatch in:
 
      -------
@@ -80,13 +97,13 @@ export function runScript(rule: string, scriptText: string, config: Object, erro
 
      Expected:
 
-       ${expectedErrorMsgs}
+       ${expected.join('       ')}
 
      Found:
 
-       ${actualErrorMsgs}
+       ${found.join('       ')}
     `;
-    assert(actualErrorMsgs === expectedErrorMsgs, msg);
+    assert(expected.length === 0 && found.length === 0, msg);
   }
 }
 

--- a/src/test/rules/helper.ts
+++ b/src/test/rules/helper.ts
@@ -73,7 +73,7 @@ export function runScript(rule: string, scriptText: string, config: Object, erro
      ${scriptText}
      -------
 
-     Found ${failures.length} errors(s):
+     Found ${failures.length} error(s):
 
        ${errorMsgs.join('       ')}
     `;

--- a/src/test/rules/terIndentRuleTests.ts
+++ b/src/test/rules/terIndentRuleTests.ts
@@ -32,6 +32,12 @@ const scripts: { valid: IScripts, invalid: IScripts } = {
   valid: [
     {
       code: Lint.Utils.dedent`
+        this.http.get('/')
+          .map(res => res.json())`,
+      options: [2, { MemberExpression: 1 }]
+    },
+    {
+      code: Lint.Utils.dedent`
         class MyComponent {
             @Input prop: number;
         }

--- a/src/test/rules/terIndentRuleTests.ts
+++ b/src/test/rules/terIndentRuleTests.ts
@@ -1,0 +1,2566 @@
+/// <reference path='../../../typings/mocha/mocha.d.ts' />
+import * as fs from 'fs';
+import * as path from 'path';
+import * as Lint from 'tslint/lib/lint';
+import { runTest, IScripts, IScriptError } from './helper';
+
+const fixture = fs.readFileSync(
+  path.join(__dirname, '../../../src/test/fixtures/indent-invalid.txt'), 'utf8'
+);
+type NumStr = number | string;
+
+function expectedErrors(errors: [[number, NumStr, NumStr]], indentType: string = 'space'): IScriptError[] {
+  return errors.map((err) => {
+    let message;
+
+    if (typeof err[1] === 'string' && typeof err[2] === 'string') {
+      message = `Expected indentation of ${err[1]} but found ${err[2]}.`;
+    } else {
+      const chars = indentType + (err[1] === 1 ? '' : 's');
+      message = `Expected indentation of ${err[1]} ${chars} but found ${err[2]}.`;
+    }
+    return { message, line: err[0] };
+  });
+}
+
+/**
+ * Borrowing tests from eslint:
+ *    https://github.com/eslint/eslint/blob/master/tests/lib/rules/no-multi-spaces.js
+ */
+const rule = 'ter-indent';
+const scripts: { valid: IScripts, invalid: IScripts } = {
+  valid: [
+    {
+      code: Lint.Utils.dedent`
+      const array = [
+          ,
+          'd',
+          3
+      ];
+      `
+    },
+    {
+      code: 'export let upgradeModule = angular.module("ui.router.upgrade", ["ui.router"]);'
+    },
+    {
+      code: Lint.Utils.dedent`
+        bridge.callHandler(
+          'getAppVersion', 'test23', function(responseData) {
+            window.ah.mobileAppVersion = responseData;
+          }
+        );
+        `,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        bridge.callHandler(
+          'getAppVersion', 'test23', function(responseData) {
+            window.ah.mobileAppVersion = responseData;
+          });
+        `,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        bridge.callHandler(
+          'getAppVersion',
+          null,
+          function responseCallback(responseData) {
+            window.ah.mobileAppVersion = responseData;
+          }
+        );
+        `,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        bridge.callHandler(
+          'getAppVersion',
+          null,
+          function responseCallback(responseData) {
+            window.ah.mobileAppVersion = responseData;
+          });
+        `,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        function doStuff(keys) {
+            _.forEach(
+                keys,
+                key => {
+                    doSomething(key);
+                }
+           );
+        }
+        `,
+      options: [4]
+    },
+    {
+      code: Lint.Utils.dedent`
+        example(
+            function () {
+                console.log('example');
+            }
+        );
+        `,
+      options: [4]
+    },
+    {
+      code: Lint.Utils.dedent`
+        let foo = somethingList
+            .filter(x => {
+                return x;
+            })
+            .map(x => {
+                return 100 * x;
+            });
+        `,
+      options: [4]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var x = 0 &&
+            {
+                a: 1,
+                b: 2
+            };
+        `,
+      options: [4]
+    },
+    {
+      code: [
+        'var x = 0 &&',
+        '\t{',
+        '\t\ta: 1,',
+        '\t\tb: 2',
+        '\t};'
+        ].join('\n'),
+      options: ['tab']
+    },
+    {
+      code: Lint.Utils.dedent`
+        var x = 0 &&
+            {
+                a: 1,
+                b: 2
+            }||
+            {
+                c: 3,
+                d: 4
+            };
+        `,
+      options: [4]
+    },
+    {
+      code: 'var x = 0 && 1;',
+      options: [4]
+    },
+    {
+      code: 'var x = 0 && { a: 1, b: 2 };',
+      options: [4]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var x = 0 &&
+            (
+                1
+            );`,
+      options: [4]
+    },
+    {
+      code: 'var x = 0 && { a: 1, b: 2 };',
+      options: [4]
+    },
+    {
+      code: Lint.Utils.dedent`
+        require('http').request({hostname: 'localhost',
+                                 port: 80}, function(res) {
+          res.end();
+        });
+        `,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        function test() {
+          return client.signUp(email, PASSWORD, { preVerified: true })
+            .then(function (result) {
+              // hi
+            })
+            .then(function () {
+              return FunctionalHelpers.clearBrowserState(self, {
+                contentServer: true,
+                contentServer1: true
+              });
+            });
+        }`,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        it('should... some lengthy test description that is forced to be' +
+          'wrapped into two lines since the line length limit is set', () => {
+          expect(true).toBe(true);
+        });
+        `,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        function test() {
+            return client.signUp(email, PASSWORD, { preVerified: true })
+                .then(function (result) {
+                    var x = 1;
+                    var y = 1;
+                }, function(err){
+                    var o = 1 - 2;
+                    var y = 1 - 2;
+                    return true;
+                })
+        }`,
+      options: [4]
+    },
+    {
+      code: Lint.Utils.dedent`
+        function test() {
+            return client.signUp(email, PASSWORD, { preVerified: true })
+            .then(function (result) {
+                var x = 1;
+                var y = 1;
+            }, function(err){
+                var o = 1 - 2;
+                var y = 1 - 2;
+                return true;
+            });
+        }`,
+      options: [4, { MemberExpression: 0 }]
+    },
+    {
+      code: '// hi',
+      options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var Command = function() {
+          var fileList = [],
+              files = []
+        
+          files.concat(fileList)
+        };
+        `,
+      options: [2, {VariableDeclarator: { var: 2, let: 2, const: 3}}]
+    },
+    {
+      code: '  ',
+      options: [2, {VariableDeclarator: 1, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        if(data) {
+          console.log('hi');
+          b = true;};`,
+      options: [2, {VariableDeclarator: 1, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        foo = () => {
+          console.log('hi');
+          return true;};`,
+      options: [2, {VariableDeclarator: 1, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        function test(data) {
+          console.log('hi');
+          return true;};`,
+      options: [2, {VariableDeclarator: 1, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var test = function(data) {
+          console.log('hi');
+        };`,
+      options: [2, {VariableDeclarator: 1, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        arr.forEach(function(data) {
+          otherdata.forEach(function(zero) {
+            console.log('hi');
+          }) });`,
+      options: [2, {VariableDeclarator: 1, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        a = [
+            ,3
+        ]`,
+      options: [4, {VariableDeclarator: 1, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        [
+          ['gzip', 'gunzip'],
+          ['gzip', 'unzip'],
+          ['deflate', 'inflate'],
+          ['deflateRaw', 'inflateRaw'],
+        ].forEach(function(method) {
+          console.log(method);
+        });
+        `,
+      options: [2, {SwitchCase: 1, VariableDeclarator: 2}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        test(123, {
+            bye: {
+                hi: [1,
+                    {
+                        b: 2
+                    }
+                ]
+            }
+        });`,
+      options: [4, {VariableDeclarator: 1, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var xyz = 2,
+            lmn = [
+                {
+                    a: 1
+                }
+            ];`,
+      options: [4, {VariableDeclarator: 1, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        lmn = [{
+            a: 1
+        },
+        {
+            b: 2
+        
+        {
+            x: 2
+        }];`,
+      options: [4, {VariableDeclarator: 1, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        abc({
+            test: [
+                [
+                    c,
+                    xyz,
+                    2
+                ].join(',')
+            ]
+        });`,
+      options: [4, {VariableDeclarator: 1, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        abc = {
+          test: [
+            [
+              c,
+              xyz,
+              2
+            ]
+          ]
+        };`,
+      options: [2, {VariableDeclarator: 1, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        abc(
+          {
+            a: 1,
+            b: 2
+          }
+        );`,
+      options: [2, {VariableDeclarator: 1, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        abc({
+            a: 1,
+            b: 2
+        });`,
+      options: [4, {VariableDeclarator: 1, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var abc = 
+          [
+            c,
+            xyz,
+            {
+              a: 1,
+              b: 2
+            }
+          ];`,
+      options: [2, {VariableDeclarator: 1, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var abc = [
+          c,
+          xyz,
+          {
+            a: 1,
+            b: 2
+          }
+        ];`,
+      options: [2, {VariableDeclarator: 1, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var abc = 5,
+            c = 2,
+            xyz = 
+            {
+              a: 1,
+              b: 2
+            };`,
+      options: [2, {VariableDeclarator: 2, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var abc = 
+            {
+              a: 1,
+              b: 2
+            };`,
+      options: [2, {VariableDeclarator: 2, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var a = new abc({
+                a: 1,
+                b: 2
+            }),
+            b = 2;`,
+      options: [4, {VariableDeclarator: 1, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var a = 2,
+          c = {
+            a: 1,
+            b: 2
+          },
+          b = 2;`,
+      options: [2, {VariableDeclarator: 1, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var x = 2,
+            y = {
+              a: 1,
+              b: 2
+            },
+            b = 2;`,
+      options: [2, {VariableDeclarator: 2, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var e = {
+              a: 1,
+              b: 2
+            },
+            b = 2;`,
+      options: [2, {VariableDeclarator: 2, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var a = {
+          a: 1,
+          b: 2
+        };`,
+      options: [2, {VariableDeclarator: 2, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        function test() {
+          if (true ||
+                    false){
+            console.log(val);
+          }
+        }`,
+      options: [2, {VariableDeclarator: 2, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        for (var val in obj)
+          if (true)
+            console.log(val);`,
+      options: [2, {VariableDeclarator: 2, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        if(true)
+          if (true)
+            if (true)
+              console.log(val);`,
+      options: [2, {VariableDeclarator: 2, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        function hi(){     var a = 1;
+          y++;                   x++;
+        }`,
+      options: [2, {VariableDeclarator: 2, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        for(;length > index; index++)if(NO_HOLES || index in self){
+          x++;
+        }`,
+      options: [2, {VariableDeclarator: 2, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        function test(){
+          switch(length){
+            case 1: return function(a){
+              return fn.call(that, a);
+            };
+          }
+        }`,
+      options: [2, {VariableDeclarator: 2, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var geometry = 2,
+        rotate = 2;`,
+      options: [2, {VariableDeclarator: 0}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var geometry,
+            rotate;`,
+      options: [4, {VariableDeclarator: 1}]
+    },
+    {
+      code: [
+        'var geometry,',
+        '\trotate;'
+      ].join('\n'),
+      options: ['tab', {VariableDeclarator: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var geometry,
+          rotate;`,
+      options: [2, {VariableDeclarator: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var geometry,
+            rotate;`,
+      options: [2, {VariableDeclarator: 2}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        let geometry,
+            rotate;`,
+      options: [2, {VariableDeclarator: 2}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        const geometry = 2,
+            rotate = 3;`,
+      options: [2, {VariableDeclarator: 2}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var geometry, box, face1, face2, colorT, colorB, sprite, padding, maxWidth,
+          height, rotate;`,
+      options: [2, {SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var geometry, box, face1, face2, colorT, colorB, sprite, padding, maxWidth;`,
+      options: [2, {SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        if (1 < 2){
+        //hi sd
+        }`,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        while (1 < 2){
+          //hi sd
+        }`,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        while (1 < 2) console.log('hi');`,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        [a, b, 
+        c].forEach((index) => {
+            index;
+        });
+        `,
+      options: [4]
+    },
+    {
+      code: Lint.Utils.dedent`
+        [a, b, 
+        c].forEach(function(index){
+            return index;
+        });
+        `,
+      options: [4]
+    },
+    {
+      code: Lint.Utils.dedent`
+        [a, b, c].forEach((index) => {
+            index;
+        });
+        `,
+      options: [4]
+    },
+    {
+      code: Lint.Utils.dedent`
+        [a, b, c].forEach(function(index){
+            return index;
+        });
+        `,
+      options: [4]
+    },
+    {
+      code: Lint.Utils.dedent`
+        switch (x) {
+            case "foo":
+                a();
+                break;
+            case "bar":
+                switch (y) {
+                    case "1":
+                        break;
+                    case "2":
+                        a = 6;
+                        break;
+                }
+            case "test":
+                break;
+        }`,
+      options: [4, { SwitchCase: 1 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        switch (x) {
+                case "foo":
+                    a();
+                    break;
+                case "bar":
+                    switch (y) {
+                            case "1":
+                                break;
+                            case "2":
+                                a = 6;
+                                break;
+                    }
+                case "test":
+                    break;
+        }`,
+      options: [4, {SwitchCase: 2}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        switch (a) {
+        case 'foo':
+            a();
+            break;
+        case 'bar':
+            switch(x){
+            case '1':
+                break;
+            case '2':
+                a = 6;
+                break;
+            }
+        }`
+    },
+    {
+      code: Lint.Utils.dedent`
+        switch (a) {
+        case 'foo':
+            a();
+            break;
+        case 'bar':
+            if(x){
+                a = 2;
+            }
+            else{
+                a = 6;
+            }
+        }`
+    },
+    {
+      code: Lint.Utils.dedent`
+        switch (a) {
+        case "foo":
+            a();
+            break;
+        case "bar":
+            if(x){
+                a = 2;
+            }
+            else
+                a = 6;
+        }`
+    },
+    {
+      code: Lint.Utils.dedent`
+        switch (a) {
+        case "foo":
+            a();
+            break;
+        case "bar":
+            a(); break;
+        case "baz":
+            a(); break;
+        }`
+    },
+    {
+      code: 'switch (0) {\n}'
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo() {
+            var a = "a";
+            switch(a) {
+            case "a":
+                return "A";
+            case "b":
+                return "B";
+            }
+        }
+        foo();`
+    },
+    {
+      code: Lint.Utils.dedent`
+        switch(value){
+            case "1":
+            case "2":
+                a();
+                break;
+            default:
+                a();
+                break;
+        }
+        switch(value){
+            case "1":
+                a();
+                break;
+            case "2":
+                break;
+            default:
+                break;
+        }`,
+      options: [4, {SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var obj = {foo: 1, bar: 2};
+        with (obj) {
+            console.log(foo + bar);
+        }
+        `
+    },
+    {
+      code: [
+        'if (a) {',
+        '    (1 + 2 + 3);', // no error on this line
+        '}'
+      ].join('\n')
+    },
+    {
+      code: 'switch(value){ default: a(); break; }\n'
+    },
+    {
+      code: "import {addons} from 'react/addons'\nimport React from 'react'",
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var a = 1,
+            b = 2,
+            c = 3;
+        `,
+      options: [4]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var a = 1
+           ,b = 2
+           ,c = 3;
+        `,
+      options: [4]
+    },
+    {
+      code: "while (1 < 2) console.log('hi')\n",
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        function salutation () {
+          switch (1) {
+            case 0: return console.log('hi')
+            case 1: return console.log('hey')
+          }
+        }
+        `,
+      options: [2, { SwitchCase: 1 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var items = [
+          {
+            foo: 'bar'
+          }
+        ];
+        `,
+      options: [2, { VariableDeclarator: 2 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        const a = 1,
+              b = 2;
+        const items1 = [
+          {
+            foo: 'bar'
+          }
+        ];
+        const items2 = Items(
+          {
+            foo: 'bar'
+          }
+        );
+        `,
+      options: [2, { VariableDeclarator: 3 }]
+
+    },
+    {
+      code: Lint.Utils.dedent`
+        const geometry = 2,
+              rotate = 3;
+        var a = 1,
+          b = 2;
+        let light = true,
+            shadow = false;`,
+      options: [2, { VariableDeclarator: { const: 3, let: 2 } }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        const abc = 5,
+              c = 2,
+              xyz =
+              {
+                a: 1,
+                b: 2
+              };
+        let abc = 5,
+          c = 2,
+          xyz =
+          {
+            a: 1,
+            b: 2
+          };
+        var abc = 5,
+            c = 2,
+            xyz =
+            {
+              a: 1,
+              b: 2
+            };
+        `,
+      options: [2, { VariableDeclarator: { var: 2, const: 3 }, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        module.exports =
+        {
+          'Unit tests':
+          {
+            rootPath: './',
+            environment: 'node',
+            tests:
+            [
+              'test/test-*.js'
+            ],
+            sources:
+            [
+              '*.js',
+              'test/**.js'
+            ]
+          }
+        };`,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var path     = require('path')
+          , crypto    = require('crypto')
+          ;
+        `,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var a = 1
+           ,b = 2
+           ;`
+    },
+    {
+      code: Lint.Utils.dedent`
+        const a: number = 1
+             ,b: number = 2
+             ;`
+    },
+    {
+      code: Lint.Utils.dedent`
+        export function create (some,
+                                argument) {
+          return Object.create({
+            a: some,
+            b: argument
+          });
+        };`,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        export function create (id, xfilter, rawType,
+                                width=defaultWidth, height=defaultHeight,
+                                footerHeight=defaultFooterHeight,
+                                padding=defaultPadding) {
+          // ... function body, indented two spaces
+        }
+        `,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var obj = {
+          foo: function () {
+            return new p()
+              .then(function (ok) {
+                return ok;
+              }, function () {
+                // ignore things
+              });
+          }
+        };
+        `,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        a.b()
+          .c(function(){
+            var a;
+          }).d.e;
+        `,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        const YO = 'bah',
+              TE = 'mah'
+
+        var res,
+            a = 5,
+            b = 4
+        `,
+      options: [2, {VariableDeclarator: { var: 2, let: 2, const: 3}}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        const YO = 'bah',
+              TE = 'mah'
+
+        var res,
+            a = 5,
+            b = 4
+
+        if (YO) console.log(TE)`,
+      options: [2, {VariableDeclarator: { var: 2, let: 2, const: 3}}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var foo = 'foo',
+          bar = 'bar',
+          baz = function() {
+
+          }
+
+        function hello () {
+
+        }
+        `,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var obj = {
+          send: function () {
+            return P.resolve({
+              type: 'POST'
+            })
+              .then(function () {
+                return true;
+              }, function () {
+                return false;
+              });
+          }
+        };
+        `,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var obj = {
+          send: function () {
+            return P.resolve({
+              type: 'POST'
+            })
+            .then(function () {
+              return true;
+            }, function () {
+              return false;
+            });
+          }
+        };
+        `,
+      options: [2, {MemberExpression: 0}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        const someOtherFunction = argument => {
+                console.log(argument);
+            },
+            someOtherValue = 'someOtherValue';
+        `
+    },
+    {
+      code: Lint.Utils.dedent`
+        [
+          'a',
+          'b'
+        ].sort().should.deepEqual([
+          'x',
+          'y'
+        ]);
+        `,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var a = 1,
+            B = class {
+              constructor(){}
+              a(){}
+              get b(){}
+            };`,
+      options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var a = 1,
+            B =
+            class {
+              constructor(){}
+              a(){}
+              get b(){}
+            },
+            c = 3;`,
+      options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        class A{
+            constructor(){}
+            a(){}
+            get b(){}
+        }`,
+      options: [4, { VariableDeclarator: 1, SwitchCase: 1 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var A = class {
+            constructor(){}
+            a(){}
+            get b(){}
+        }`,
+      options: [4, { VariableDeclarator: 1, SwitchCase: 1 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var a = {
+          some: 1
+        , name: 2
+        };
+        `,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        a.c = {
+            aa: function() {
+                'test1';
+                return 'aa';
+            }
+            , bb: function() {
+                return this.bb();
+            }
+        };
+        `,
+      options: [4]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var a =
+        {
+            actions:
+            [
+                {
+                    name: 'compile'
+                }
+            ]
+        };
+        `,
+      options: [4, { VariableDeclarator: 0, SwitchCase: 1 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var a =
+        [
+            {
+                name: 'compile'
+            }
+        ];
+        `,
+      options: [4, {VariableDeclarator: 0, SwitchCase: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        const func = function (opts) {
+            return Promise.resolve()
+            .then(() => {
+                [
+                    'ONE', 'TWO'
+                ].forEach(command => { doSomething(); });
+            });
+        };`,
+      options: [4, {MemberExpression: 0}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        const func = function (opts) {
+            return Promise.resolve()
+                .then(() => {
+                    [
+                        'ONE', 'TWO'
+                    ].forEach(command => { doSomething(); });
+                });
+        };`,
+      options: [4]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var haveFun = function () {
+            SillyFunction(
+                {
+                    value: true,
+                },
+                {
+                    _id: true,
+                }
+            );
+        };`,
+      options: [4]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var haveFun = function () {
+            new SillyFunction(
+                {
+                    value: true,
+                },
+                {
+                    _id: true,
+                }
+            );
+        };`,
+      options: [4]
+    },
+    {
+      code: Lint.Utils.dedent`
+        let object1 = {
+          doThing() {
+            return _.chain([])
+              .map(v => (
+                {
+                  value: true,
+                }
+              ))
+              .value();
+          }
+        };`,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        class Foo
+          extends Bar {
+          baz() {}
+        }`,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        class Foo extends
+          Bar {
+          baz() {}
+        }`,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        fs.readdirSync(path.join(__dirname, '../rules')).forEach(name => {
+          files[name] = foo;
+        });`,
+      options: [2, { outerIIFEBody: 0 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        (function(){
+        function foo(x) {
+          return x + 1;
+        }
+        })();`,
+      options: [2, { outerIIFEBody: 0 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        (function(){
+                function foo(x) {
+                    return x + 1;
+                }
+        })();`,
+      options: [4, { outerIIFEBody: 2 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        (function(x, y){
+        function foo(x) {
+          return x + 1;
+        }
+        })(1, 2);`,
+      options: [2, { outerIIFEBody: 0 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        (function(){
+        function foo(x) {
+          return x + 1;
+        }
+        }());`,
+      options: [2, { outerIIFEBody: 0 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        !function(){
+        function foo(x) {
+          return x + 1;
+        }
+        }();`,
+      options: [2, { outerIIFEBody: 0 }]
+    },
+    {
+      code: [
+        '!function(){',
+        '\t\t\tfunction foo(x) {',
+        '\t\t\t\treturn x + 1;',
+        '\t\t\t}',
+        '}();'
+      ].join('\n'),
+      options: ['tab', { outerIIFEBody: 3 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var out = function(){
+          function fooVar(x) {
+            return x + 1;
+          }
+        };`,
+      options: [2, { outerIIFEBody: 0 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var ns = function(){
+        function fooVar(x) {
+          return x + 1;
+        }
+        }();`,
+      options: [2, { outerIIFEBody: 0 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        ns = function(){
+        function fooVar(x) {
+          return x + 1;
+        }
+        }();`,
+      options: [2, { outerIIFEBody: 0 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var ns = (function(){
+        function fooVar(x) {
+          return x + 1;
+        }
+        }(x));`,
+      options: [2, { outerIIFEBody: 0 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var ns = (function(){
+                function fooVar(x) {
+                    return x + 1;
+                }
+        }(x));`,
+      options: [4, { outerIIFEBody: 2 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var obj = {
+          foo: function() {
+            return true;
+          }
+        };`,
+      options: [2, { outerIIFEBody: 0 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        while (
+          function() {
+            return true;
+          }()) {
+
+          x = x + 1;
+        };`,
+      options: [2, { outerIIFEBody: 20 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        (() => {
+        function foo(x) {
+          return x + 1;
+        }
+        })();`,
+      options: [2, { outerIIFEBody: 0 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo() {
+        }`,
+      options: ['tab', { outerIIFEBody: 0 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        ;(() => {
+        function foo(x) {
+          return x + 1;
+        }
+        })();`,
+      options: [2, { outerIIFEBody: 0 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        if(data) {
+          console.log('hi');
+        }`,
+      options: [2, { outerIIFEBody: 0 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        Buffer.length`,
+      options: [4, { MemberExpression: 1 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        Buffer
+            .indexOf('a')
+            .toString()`,
+      options: [4, { MemberExpression: 1 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        Buffer.
+            length`,
+      options: [4, { MemberExpression: 1 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        Buffer
+            .foo
+            .bar`,
+      options: [4, { MemberExpression: 1 }]
+    },
+    {
+      code: [
+        'Buffer',
+        '\t.foo',
+        '\t.bar'
+      ].join('\n'),
+      options: ['tab', { MemberExpression: 1 }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        Buffer
+            .foo
+            .bar`,
+      options: [2, {MemberExpression: 2}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        MemberExpression
+        .
+          .o
+            .
+         .default();`,
+      options: [4]
+    },
+    {
+      code: Lint.Utils.dedent`
+        foo = bar.baz()
+                .bip();`,
+      options: [4, {MemberExpression: 1}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        if (foo) {
+          bar();
+        } else if (baz) {
+          foobar();
+        } else if (qux) {
+          qux();
+        }`,
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo(aaa,
+          bbb, ccc, ddd) {
+            bar();
+        }`,
+      options: [2, {FunctionDeclaration: {parameters: 1, body: 2}}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo(aaa, bbb,
+              ccc, ddd) {
+          bar();
+        }`,
+      options: [2, {FunctionDeclaration: {parameters: 3, body: 1}}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo(aaa,
+            bbb,
+            ccc) {
+                    bar();
+        }`,
+      options: [4, {FunctionDeclaration: {parameters: 1, body: 3}}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo(aaa,
+                     bbb, ccc,
+                     ddd, eee, fff) {
+          bar();
+        }`,
+      options: [2, {FunctionDeclaration: {parameters: 'first', body: 1}}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo(aaa, bbb)
+        {
+              bar();
+        }`,
+      options: [2, {FunctionDeclaration: {body: 3}}] // FIXME: what is the default for `parameters`?
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo(
+          aaa,
+          bbb) {
+            bar();
+        }`,
+      options: [2, {FunctionDeclaration: {parameters: 'first', body: 2}}] // FIXME: make sure this is correct
+    },
+    {
+      code: Lint.Utils.dedent`
+        var foo = function(aaa,
+            bbb,
+            ccc,
+            ddd) {
+        bar();
+        }`,
+      options: [2, {FunctionExpression: {parameters: 2, body: 0}}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var foo = function(aaa,
+          bbb,
+          ccc) {
+                            bar();
+        }`,
+      options: [2, {FunctionExpression: {parameters: 1, body: 10}}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var foo = function(aaa,
+                           bbb, ccc, ddd,
+                           eee, fff) {
+            bar();
+        }`,
+      options: [4, {FunctionExpression: {parameters: 'first', body: 1}}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var foo = function(
+          aaa, bbb, ccc,
+          ddd, eee) {
+              bar();
+        }`,
+      options: [2, {FunctionExpression: {parameters: 'first', body: 3}}] // FIXME: make sure this is correct
+    },
+    {
+      code: [
+        'function foo() {',
+        '  bar();',
+        '  \tbaz();',
+        '\t   \t\t\t  \t\t\t  \t   \tqux();',
+        '}'
+      ].join('\n'),
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo() {
+          function bar() {
+            baz();
+          }
+        }`,
+      options: [2, {FunctionDeclaration: {body: 1}}]
+    },
+    {
+      code: [
+        'function foo() {',
+        '  bar();',
+        '   \t\t}'
+      ].join('\n'),
+      options: [2]
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo() {
+          function bar(baz,
+              qux) {
+            foobar();
+          }
+        }`,
+      options: [2, {FunctionDeclaration: {body: 1, parameters: 2}}]
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo() {
+          var bar = function(baz,
+                qux) {
+            foobar();
+          };
+        }`,
+      options: [2, {FunctionExpression: {parameters: 3}}]
+    }
+  ],
+  invalid: [
+    {
+      code: Lint.Utils.dedent`
+        var a = b;
+        if (a) {
+        b();
+        }`,
+      options: [2],
+      errors: expectedErrors([[3, 2, 0]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        if (array.some(function(){
+          return true;
+        })) {
+        a++; // ->
+          b++;
+            c++; // <-
+        }`,
+      options: [2],
+      errors: expectedErrors([[4, 2, 0], [6, 2, 4]])
+    },
+    {
+      code: '\nif (a){\n\tb=c;\n\t\tc=d;\ne=f;\n}',
+      options: ['tab'],
+      errors: expectedErrors(
+        [
+          [3, 1, 2],
+          [4, 1, 0]
+        ],
+        'tab'
+      )
+    },
+    {
+      code: '\nif (a){\n    b=c;\n      c=d;\n e=f;\n}',
+      options: [4],
+      errors: expectedErrors([[3, 4, 6], [4, 4, 1]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        switch(value){
+            case "1":
+                a();
+            break;
+            case "2":
+                a();
+            break;
+            default:
+                a();
+                break;
+        }`,
+      options: [4, { SwitchCase: 1 }],
+      errors: expectedErrors([[4, 8, 4], [7, 8, 4]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var x = 0 &&
+            {
+               a: 1,
+                  b: 2
+            };`,
+      options: [4],
+      errors: expectedErrors([[3, 8, 7], [4, 8, 10]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        switch(value){
+            case "1":
+                a();
+                break;
+            case "2":
+                a();
+                break;
+            default:
+            break;
+        }`,
+      options: [4, {SwitchCase: 1}],
+      errors: expectedErrors([[9, 8, 4]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        switch(value){
+            case "1":
+            case "2":
+                a();
+                break;
+            default:
+                break;
+        }
+        switch(value){
+            case "1":
+            break;
+            case "2":
+                a();
+            break;
+            default:
+                a();
+            break;
+        }`,
+      options: [4, { SwitchCase: 1 }],
+      errors: expectedErrors([[11, 8, 4], [14, 8, 4], [17, 8, 4]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        switch(value){
+        case "1":
+                a();
+                break;
+            case "2":
+                break;
+            default:
+                break;
+        }`,
+      options: [4],
+      errors: expectedErrors([
+        [3, 4, 8],
+        [4, 4, 8],
+        [5, 0, 4],
+        [6, 4, 8],
+        [7, 0, 4],
+        [8, 4, 8]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var obj = {foo: 1, bar: 2};
+        with (obj) {
+        console.log(foo + bar);
+        }`,
+      errors: expectedErrors([[3, 4, 0]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        switch (a) {
+        case '1':
+        b();
+        break;
+        default:
+        c();
+        break;
+        }`,
+      options: [4, { SwitchCase: 1 }],
+      errors: expectedErrors([
+        [2, 4, 0],
+        [3, 8, 0],
+        [4, 8, 0],
+        [5, 4, 0],
+        [6, 8, 0],
+        [7, 8, 0]
+      ])
+    },
+    {
+      code: '\nwhile (a)\nb();\n',
+      options: [4],
+      errors: expectedErrors([
+        [2, 4, 0]
+      ])
+    },
+    {
+      code: '\nfor (;;) \nb();\n',
+      options: [4],
+      errors: expectedErrors([
+        [2, 4, 0]
+      ])
+    },
+    {
+      code: '\nfor (a in x) \nb();',
+      options: [4],
+      errors: expectedErrors([
+        [2, 4, 0]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        do
+        b();
+        while(true)`,
+      options: [4],
+      errors: expectedErrors([
+        [2, 4, 0]
+      ])
+    },
+    {
+      code: '\nif(true) \nb();',
+      options: [4],
+      errors: expectedErrors([
+        [2, 4, 0]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var test = {
+              a: 1,
+            b: 2
+            };`,
+      options: [2],
+      errors: expectedErrors([
+        [2, 2, 6],
+        [3, 2, 4],
+        [4, 0, 4]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var a = function() {
+              a++;
+            b++;
+                  c++;
+            },
+            b;`,
+      options: [4],
+      errors: expectedErrors([
+        [2, 8, 6],
+        [3, 8, 4],
+        [4, 8, 10]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var a = 1,
+        b = 2,
+        c = 3;`,
+      options: [4],
+      errors: expectedErrors([
+        [2, 4, 0],
+        [3, 4, 0]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        [a, b,
+        c].forEach((index) => {
+          index;
+        });`,
+      options: [4],
+      errors: expectedErrors([
+        [3, 4, 2]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        [a, b,
+        c].forEach(function(index){
+          return index;
+        });`,
+      options: [4],
+      errors: expectedErrors([
+        [3, 4, 2]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        [a, b, c].forEach((index) => {
+          index;
+        });`,
+      options: [4],
+      errors: expectedErrors([
+        [2, 4, 2]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        [a, b, c].forEach(function(index){
+          return index;
+        });`,
+      options: [4],
+      errors: expectedErrors([
+        [2, 4, 2]
+      ])
+    },
+    {
+      code: "\nwhile (1 < 2)\nconsole.log('foo')\n  console.log('bar')",
+      options: [2],
+      errors: expectedErrors([
+        [2, 2, 0],
+        [3, 0, 2]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        function salutation () {
+          switch (1) {
+          case 0: return console.log('hi')
+            case 1: return console.log('hey')
+          }
+        }`,
+      options: [2, { SwitchCase: 1 }],
+      errors: expectedErrors([
+        [3, 4, 2]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var geometry, box, face1, face2, colorT, colorB, sprite, padding, maxWidth,
+        height, rotate;`,
+      options: [2, { SwitchCase: 1 }],
+      errors: expectedErrors([
+        [2, 2, 0]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        switch (a) {
+        case '1':
+        b();
+        break;
+        default:
+        c();
+        break;
+        }`,
+      options: [4, { SwitchCase: 2 }],
+      errors: expectedErrors([
+        [2, 8, 0],
+        [3, 12, 0],
+        [4, 12, 0],
+        [5, 8, 0],
+        [6, 12, 0],
+        [7, 12, 0]
+      ])
+    },
+    {
+      code: '\nvar geometry,\nrotate;',
+      options: [2, { VariableDeclarator: 1 }],
+      errors: expectedErrors([
+        [2, 2, 0]
+      ])
+    },
+    {
+      code: '\nvar geometry,\n  rotate;',
+      options: [2, { VariableDeclarator: 2 }],
+      errors: expectedErrors([
+        [2, 4, 2]
+      ])
+    },
+    {
+      code: '\nvar geometry,\n\trotate;',
+      options: ['tab', { VariableDeclarator: 2 }],
+      errors: expectedErrors(
+        [
+          [2, 2, 1]
+        ],
+        'tab'
+      )
+    },
+    {
+      code: '\nlet geometry,\n  rotate;',
+      options: [2, { VariableDeclarator: 2 }],
+      errors: expectedErrors([
+        [2, 4, 2]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        if(true)
+          if (true)
+            if (true)
+            console.log(val);`,
+      options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
+      errors: expectedErrors([
+        [4, 6, 4]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var a = {
+            a: 1,
+            b: 2
+        }`,
+      options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
+      errors: expectedErrors([
+        [2, 2, 4],
+        [3, 2, 4]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var a = [
+            a,
+            b
+        ]`,
+      options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
+      errors: expectedErrors([
+        [2, 2, 4],
+        [3, 2, 4]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        let a = [
+            a,
+            b
+        ]`,
+      options: [2, { VariableDeclarator: { let: 2 }, SwitchCase: 1 }],
+      errors: expectedErrors([
+        [2, 2, 4],
+        [3, 2, 4]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var a = new Test({
+              a: 1
+          }),
+            b = 4;`,
+      options: [4],
+      errors: expectedErrors([
+        [2, 8, 6],
+        [3, 4, 2]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var a = new Test({
+              a: 1
+            }),
+            b = 4;
+        const a = new Test({
+              a: 1
+            }),
+            b = 4;`,
+      options: [2, { VariableDeclarator: { var: 2 } }],
+      errors: expectedErrors([
+        [6, 4, 6],
+        [7, 2, 4],
+        [8, 2, 4]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var abc = 5,
+            c = 2,
+            xyz =
+             {
+               a: 1,
+                b: 2
+             };`,
+      options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
+      errors: expectedErrors([
+        [4, 4, 5],
+        [5, 6, 7],
+        [6, 6, 8],
+        [7, 4, 5]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var abc =
+             {
+               a: 1,
+                b: 2
+             };`,
+      options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
+      errors: expectedErrors([
+        [2, 4, 5],
+        [3, 6, 7],
+        [4, 6, 8],
+        [5, 4, 5]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var path     = require('path')
+         , crypto    = require('crypto')
+        ;`,
+      options: [2],
+      errors: expectedErrors([
+        [3, 1, 0]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var a = 1
+           ,b = 2
+        ;`,
+      errors: expectedErrors([
+        [3, 3, 0]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        class A{
+          constructor(){}
+            a(){}
+            get b(){}
+        }`,
+      options: [4, { VariableDeclarator: 1, SwitchCase: 1 }],
+      errors: expectedErrors([[2, 4, 2]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var A = class {
+          constructor(){}
+            a(){}
+          get b(){}
+        };`,
+      options: [4, { VariableDeclarator: 1, SwitchCase: 1 }],
+      errors: expectedErrors([[2, 4, 2], [4, 4, 2]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var a = 1,
+            B = class {
+            constructor(){}
+              a(){}
+              get b(){}
+            };`,
+      options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
+      errors: expectedErrors([[3, 6, 4]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        {
+            if(a){
+                foo();
+            }
+          else{
+                bar();
+            }
+        }`,
+      options: [4],
+      errors: expectedErrors([[5, 4, 2]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        {
+            if(a){
+                foo();
+            }
+          else
+                bar();
+
+        }`,
+      options: [4],
+      errors: expectedErrors([[5, 4, 2]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        {
+            if(a)
+                foo();
+          else
+                bar();
+        }`,
+      options: [4],
+      errors: expectedErrors([[4, 4, 2]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        (function(){
+          function foo(x) {
+            return x + 1;
+          }
+        })();`,
+      options: [2, { outerIIFEBody: 0 }],
+      errors: expectedErrors([[2, 0, 2]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        (function(){
+            function foo(x) {
+                return x + 1;
+            }
+        })();`,
+      options: [4, { outerIIFEBody: 2 }],
+      errors: expectedErrors([[2, 8, 4]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        if(data) {
+        console.log('hi');
+        }`,
+      options: [2, { outerIIFEBody: 0 }],
+      errors: expectedErrors([[2, 2, 0]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var ns = function(){
+            function fooVar(x) {
+                return x + 1;
+            }
+        }(x);`,
+      options: [4, { outerIIFEBody: 2 }],
+      errors: expectedErrors([[2, 8, 4]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var obj = {
+          foo: function() {
+          return true;
+          }()
+        };`,
+      options: [2, { outerIIFEBody: 0 }],
+      errors: expectedErrors([[3, 4, 2]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        typeof function() {
+            function fooVar(x) {
+              return x + 1;
+            }
+        }();`,
+      options: [2, { outerIIFEBody: 2 }],
+      errors: expectedErrors([[2, 2, 4]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        {
+        \t!function(x) {
+        \t\t\t\treturn x + 1;
+        \t}()
+        };`,
+      options: ['tab', { outerIIFEBody: 3 }],
+      errors: expectedErrors([[3, 2, 4]], 'tab')
+    },
+    {
+      code: '\nBuffer\n.toString()',
+      options: [4, { MemberExpression: 1 }],
+      errors: expectedErrors([[2, 4, 0]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        Buffer
+            .indexOf('a')
+        .toString()`,
+      options: [4, { MemberExpression: 1 }],
+      errors: expectedErrors([[3, 4, 0]])
+    },
+    {
+      code: '\nBuffer.\nlength',
+      options: [4, { MemberExpression: 1 }],
+      errors: expectedErrors([[2, 4, 0]])
+    },
+    {
+      code: '\nBuffer.\n\t\tlength',
+      options: ['tab', { MemberExpression: 1 }],
+      errors: expectedErrors([[2, 1, 2]], 'tab')
+    },
+    {
+      code: '\nBuffer\n  .foo\n  .bar',
+      options: [2, { MemberExpression: 2 }],
+      errors: expectedErrors([[2, 4, 2], [3, 4, 2]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        if (foo) bar();
+        else if (baz) foobar();
+          else if (qux) qux();`,
+      options: [2],
+      errors: expectedErrors([[3, 0, 2]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        if (foo) bar();
+        else if (baz) foobar();
+          else qux();`,
+      options: [2],
+      errors: expectedErrors([[3, 0, 2]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        foo();
+          if (baz) foobar();
+          else qux();`,
+      options: [2],
+      errors: expectedErrors([[2, 0, 2], [3, 0, 2]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        if (foo) bar();
+        else if (baz) foobar();
+             else if (bip) {
+               qux();
+             }`,
+      options: [2],
+      errors: expectedErrors([[3, 0, 5]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        if (foo) bar();
+        else if (baz) {
+            foobar();
+             } else if (boop) {
+               qux();
+             }`,
+      options: [2],
+      errors: expectedErrors([[3, 2, 4], [4, 0, 5]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo(aaa,
+            bbb, ccc, ddd) {
+              bar();
+        }`,
+      options: [2, { FunctionDeclaration: { parameters: 1, body: 2 } }],
+      errors: expectedErrors([[2, 2, 4], [3, 4, 6]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo(aaa, bbb,
+          ccc, ddd) {
+        bar();
+        }",
+        utput:
+        function foo(aaa, bbb,
+              ccc, ddd) {
+          bar();
+        }`,
+      options: [2, { FunctionDeclaration: { parameters: 3, body: 1 } }],
+      errors: expectedErrors([[2, 6, 2], [3, 2, 0]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo(aaa,
+                bbb,
+          ccc) {
+              bar();
+        }`,
+      options: [4, { FunctionDeclaration: { parameters: 1, body: 3 } }],
+      errors: expectedErrors([[2, 4, 8], [3, 4, 2], [4, 12, 6]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo(aaa,
+          bbb, ccc,
+                           ddd, eee, fff) {
+           bar();
+        }`,
+      options: [2, { FunctionDeclaration: { parameters: 'first', body: 1 } }],
+      errors: expectedErrors([[2, 13, 2], [3, 13, 19], [4, 2, 3]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo(aaa, bbb)
+        {
+        bar();
+        }`,
+      options: [2, { FunctionDeclaration: { body: 3 } }],
+      errors: expectedErrors([[3, 6, 0]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo(
+        aaa,
+            bbb) {
+        bar();
+        }`,
+      options: [2, { FunctionDeclaration: { parameters: 'first', body: 2 } }],
+      errors: expectedErrors([[3, 0, 4], [4, 4, 0]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var foo = function(aaa,
+          bbb,
+            ccc,
+              ddd) {
+          bar();
+        }`,
+      options: [2, { FunctionExpression: { parameters: 2, body: 0 } }],
+      errors: expectedErrors([[2, 4, 2], [4, 4, 6], [5, 0, 2]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var foo = function(aaa,
+           bbb,
+         ccc) {
+          bar();
+        }`,
+      options: [2, { FunctionExpression: { parameters: 1, body: 10 }}],
+      errors: expectedErrors([[2, 2, 3], [3, 2, 1], [4, 20, 2]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var foo = function(aaa,
+          bbb, ccc, ddd,
+                                eee, fff) {
+                bar();
+        }`,
+      options: [4, { FunctionExpression: { parameters: 'first', body: 1 } }],
+      errors: expectedErrors([[2, 19, 2], [3, 19, 24], [4, 4, 8]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var foo = function(
+        aaa, bbb, ccc,
+            ddd, eee) {
+          bar();
+        }`,
+      options: [2, {FunctionExpression: { parameters: 'first', body: 3 } }],
+      errors: expectedErrors([[3, 0, 4], [4, 6, 2]])
+    },
+    {
+      code: '\nvar foo = bar;\n\t\t\tvar baz = qux;',
+      options: [2],
+      errors: expectedErrors([[2, '0 spaces', '3 tabs']])
+    },
+    {
+      code: '\nfunction foo() {\n\tbar();\n  baz();\n              qux();\n}',
+      options: ['tab'],
+      errors: expectedErrors([[3, '1 tab', '2 spaces'], [4, '1 tab', '14 spaces']], 'tab')
+    },
+    {
+      code: [
+        '\nfunction foo() {',
+        '  bar();',
+        '\t\t}'
+      ].join('\n'),
+      options: [2],
+      errors: expectedErrors([[3, '0 spaces', '2 tabs']])
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo() {
+          function bar() {
+                baz();
+          }
+        }`,
+      options: [2, { FunctionDeclaration: { body: 1 } }],
+      errors: expectedErrors([[3, 4, 8]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo() {
+          function bar(baz,
+            qux) {
+            foobar();
+          }
+        }`,
+      options: [2, { FunctionDeclaration: { body: 1, parameters: 2 } }],
+      errors: expectedErrors([[3, 6, 4]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo() {
+          var bar = function(baz,
+                  qux) {
+            foobar();
+          };
+        }`,
+      options: [2, { FunctionExpression: { parameters: 3 } }],
+      errors: expectedErrors([[3, 8, 10]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        /**/var b; // NO ERROR: single line multi-line comments followed by code is OK
+        /*
+         *
+         */ var b; // ERROR: multi-line comments followed by code is not OK
+        `,
+      options: [2],
+      errors: expectedErrors([
+        [4, 0, 1]
+      ])
+    },
+    {
+      code: '\n' + fixture,
+      options: [2, { SwitchCase: 1, MemberExpression: 1 }],
+      errors: expectedErrors([
+        [5, 2, 4],
+        [10, 4, 6],
+        [11, 2, 4],
+        [15, 4, 2],
+        [16, 2, 4],
+        [23, 2, 4],
+        [29, 2, 4],
+        [31, 4, 2],
+        [36, 4, 6],
+        [38, 2, 4],
+        [39, 4, 2],
+        [40, 2, 0],
+        [46, 0, 1],
+        [54, 2, 4],
+        [114, 4, 2],
+        [120, 4, 6],
+        [124, 4, 2],
+        [134, 4, 6],
+        [138, 2, 3],
+        [139, 2, 3],
+        [143, 4, 0],
+        [151, 4, 6],
+        [159, 4, 2],
+        [161, 4, 6],
+        [175, 2, 0],
+        [177, 2, 4],
+        [189, 2, 0],
+        [193, 6, 4],
+        [195, 6, 8],
+        [304, 4, 6],
+        [306, 4, 8],
+        [307, 2, 4],
+        [308, 2, 4],
+        [311, 4, 6],
+        [312, 4, 6],
+        [313, 4, 6],
+        [314, 2, 4],
+        [315, 2, 4],
+        [318, 4, 6],
+        [319, 4, 6],
+        [320, 4, 6],
+        [321, 2, 4],
+        [322, 2, 4],
+        [326, 2, 1],
+        [327, 2, 1],
+        [328, 2, 1],
+        [329, 2, 1],
+        [330, 2, 1],
+        [331, 2, 1],
+        [332, 2, 1],
+        [333, 2, 1],
+        [334, 2, 1],
+        [335, 2, 1],
+        [340, 2, 4],
+        [341, 2, 0],
+        [344, 2, 4],
+        [345, 2, 0],
+        [348, 2, 4],
+        [349, 2, 0],
+        [355, 2, 0],
+        [357, 2, 4],
+        [361, 4, 6],
+        [362, 2, 4],
+        [363, 2, 4],
+        [368, 2, 0],
+        [370, 2, 4],
+        [374, 4, 6],
+        [376, 4, 2],
+        [383, 2, 0],
+        [385, 2, 4],
+        [390, 2, 0],
+        [392, 2, 4],
+        [409, 2, 0],
+        [410, 2, 4],
+        [416, 2, 0],
+        [417, 2, 4],
+        [422, 2, 4],
+        [423, 2, 0],
+        [427, 2, 6],
+        [428, 2, 8],
+        [429, 2, 4],
+        [430, 0, 4],
+        [433, 2, 4],
+        [434, 0, 4],
+        [437, 2, 0],
+        [438, 0, 4],
+        [451, 2, 0],
+        [453, 2, 4],
+        [499, 6, 8],
+        [500, 10, 8],
+        [501, 8, 6],
+        [506, 6, 8]
+      ])
+    }
+  ]
+};
+
+describe(rule, () => {
+
+  it('should pass when using the correct indentation', () => {
+    runTest(rule, scripts.valid);
+  });
+
+  it('should fail when using wrong indentation', () => {
+    runTest(rule, scripts.invalid);
+  });
+
+});

--- a/src/test/rules/terIndentRuleTests.ts
+++ b/src/test/rules/terIndentRuleTests.ts
@@ -32,6 +32,13 @@ const scripts: { valid: IScripts, invalid: IScripts } = {
   valid: [
     {
       code: Lint.Utils.dedent`
+        class MyComponent {
+            @Input prop: number;
+        }
+      `
+    },
+    {
+      code: Lint.Utils.dedent`
       const array = [
           ,
           'd',
@@ -1600,6 +1607,14 @@ const scripts: { valid: IScripts, invalid: IScripts } = {
     }
   ],
   invalid: [
+    {
+      code: Lint.Utils.dedent`
+        class MyComponent {
+         @Input prop: number;
+        }
+      `,
+      errors: expectedErrors([[2, 4, 1]])
+    },
     {
       code: Lint.Utils.dedent`
         var a = b;


### PR DESCRIPTION
This is a direct port of eslint `indent` rule. As such, it only seems to cover the basics of es6, that is, there is nothing on decorators.

A few modifications were done to the test helpers to facilitate creating tests for the rule.