### PR TITLE
[feat] added ter-max-len

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ These rules are purely matters of style and are quite subjective.
 |:x:|[linebreak-style](http://eslint.org/docs/rules/linebreak-style)|linebreak-style|disallow mixed 'LF' and 'CRLF' as linebreaks|
 |:x:|[lines-around-comment](http://eslint.org/docs/rules/lines-around-comment)|lines-around-comment|enforce empty lines around comments|
 |:x:|[max-depth](http://eslint.org/docs/rules/max-depth)|max-depth|specify the maximum depth that blocks can be nested|
-|:ballot_box_with_check:|[max-len](http://eslint.org/docs/rules/max-len)|[max-line-length](http://palantir.github.io/tslint/rules/max-line-length)|specify the maximum length of a line in your program|
+|:white_check_mark:|[max-len](http://eslint.org/docs/rules/max-len)|[ter-max-len](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/docs/rules/terMaxLenRule.md)|enforce a maximum line length|
 |:ballot_box_with_check:|[max-lines](http://eslint.org/docs/rules/max-lines)|[max-file-line-count](http://palantir.github.io/tslint/rules/max-file-line-count)|enforce a maximum number of lines per file|
 |:x:|[max-nested-callbacks](http://eslint.org/docs/rules/max-nested-callbacks)|max-nested-callbacks|specify the maximum depth callbacks can be nested|
 |:x:|[max-params](http://eslint.org/docs/rules/max-params)|max-params|specify the number of parameters that can be used in the function declaration|

--- a/src/docs/rules/terIndentRule.md
+++ b/src/docs/rules/terIndentRule.md
@@ -3,48 +3,17 @@
 
 enforce consistent indentation
 
-### Usage
-
-```json
-"indent": [
-    true,
-    "tab"
-  ]
-```
-
-```json
-"indent": [
-    true,
-    2
-  ]
-```
-
-```json
-"indent": [
-    true,
-    2,
-    {
-      "FunctionExpression": {
-        "parameters": 1,
-        "body": 1
-      }
-    }
-  ]
-```
-
-<!-- End:AutoDoc -->
-
-### Rationale
+#### Rationale
 
 Using only one of tabs or spaces for indentation leads to more consistent editor behavior,
 cleaner diffs in version control, and easier programmatic manipulation.
 
-### Options
+### Config
 
 The string 'tab' or an integer indicating the number of spaces to use per tab.
 
 An object may be provided to fine tune the indentation rules:
-
+      
   * `"SwitchCase"` (default: 0) enforces indentation level for `case` clauses in
                      `switch` statements
   * `"VariableDeclarator"` (default: 1) enforces indentation level for `var` declarators;
@@ -65,6 +34,110 @@ An object may be provided to fine tune the indentation rules:
                          indentation level, or the string `"first"` indicating that all
                          parameters of the declaration must be aligned with the first parameter.
       * `"body"` (default: 1) enforces indentation level for the body of a function expression.
+
+#### Examples
+
+```json
+"ter-indent": [true, "tab"]
+```
+
+```json
+"ter-indent": [true, 2]
+```
+
+```json
+"ter-indent": [
+  true,
+  2,
+  {
+    "FunctionExpression": {
+      "parameters": 1,
+      "body": 1
+    }
+  }
+]      
+```
+#### Schema
+
+```json
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "number",
+      "minimum": "0"
+    },
+    {
+      "type": "string",
+      "enum": [
+        "tab"
+      ]
+    },
+    {
+      "type": "object",
+      "properties": {
+        "SwitchCase": {
+          "type": "number",
+          "minimum": 0
+        },
+        "VariableDeclarator": {
+          "type": "object",
+          "properties": {
+            "var": {
+              "type": "number",
+              "minimum": 0
+            },
+            "let": {
+              "type": "number",
+              "minimum": 0
+            },
+            "const": {
+              "type": "number",
+              "minimum": 0
+            }
+          }
+        },
+        "outerIIFEBody": {
+          "type": "number"
+        },
+        "FunctionDeclaration": {
+          "type": "object",
+          "properties": {
+            "parameters": {
+              "type": "number",
+              "minimum": 0
+            },
+            "body": {
+              "type": "number",
+              "minimum": 0
+            }
+          }
+        },
+        "FunctionExpression": {
+          "type": "object",
+          "properties": {
+            "parameters": {
+              "type": "number",
+              "minimum": 0
+            },
+            "body": {
+              "type": "number",
+              "minimum": 0
+            }
+          }
+        },
+        "MemberExpression": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minLength": 1,
+  "maxLength": 2
+}
+```
+<!-- End:AutoDoc -->
 
 ### TSLint Rule: `indent`
 

--- a/src/docs/rules/terMaxLenRule.md
+++ b/src/docs/rules/terMaxLenRule.md
@@ -3,4 +3,117 @@
 
 enforce a maximum line length
 
+#### Rationale
+
+Limiting the length of a line of code improves code readability.
+It also makes comparing code side-by-side easier and improves compatibility with
+various editors, IDEs, and diff viewers.
+
+### Config
+
+An integer indicating the maximum length of lines followed by an optional integer specifying
+the character width for tab characters.
+
+An optional object may be provided to fine tune the rule:
+
+* `"code"`: (default 80) enforces a maximum line length
+* `"tabWidth"`: (default 4) specifies the character width for tab characters
+* `"comments"`: enforces a maximum line length for comments; defaults to value of code
+* `"ignorePattern"`: ignores lines matching a regular expression; can only match a single
+                           line and need to be double escaped when written in JSON
+* `"ignoreComments"`: true ignores all trailing comments and comments on their own line
+* `"ignoreTrailingComments"`: true ignores only trailing comments
+* `"ignoreUrls"`: true ignores lines that contain a URL
+* `"ignoreStrings"`: true ignores lines that contain a double-quoted or single-quoted string
+* `"ignoreTemplateLiterals"`: true ignores lines that contain a template literal
+* `"ignoreRegExpLiterals"`: true ignores lines that contain a RegExp literal
+* `"ignoreImports"`: true ignores lines that contain an import module specifier
+
+#### Examples
+
+```json
+"ter-max-len": [true, 100]
+```
+
+```json
+"ter-max-len": [
+  true,
+  100,
+  2,
+  {
+    "ignoreUrls": true,
+    "ignorePattern": "^\\s*(let|const)\\s.+=\\s*require\\s*\\("
+  }
+]
+```
+
+```json
+"ter-max-len": [
+  true,
+  {
+    "code": 100,
+    "tabWidth": 2,
+    "ignoreImports": true,
+    "ignoreUrls": true,
+    "ignorePattern": "^\\s*(let|const)\\s.+=\\s*require\\s*\\("
+  }
+]
+```
+#### Schema
+
+```json
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "number",
+      "minimum": "0"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "number",
+          "minumum": "1"
+        },
+        "comments": {
+          "type": "number",
+          "minumum": "1"
+        },
+        "tabWidth": {
+          "type": "number",
+          "minumum": "1"
+        },
+        "ignorePattern": {
+          "type": "string"
+        },
+        "ignoreComments": {
+          "type": "boolean"
+        },
+        "ignoreStrings": {
+          "type": "boolean"
+        },
+        "ignoreUrls": {
+          "type": "boolean"
+        },
+        "ignoreTemplateLiterals": {
+          "type": "boolean"
+        },
+        "ignoreRegExpLiterals": {
+          "type": "boolean"
+        },
+        "ignoreTrailingComments": {
+          "type": "boolean"
+        },
+        "ignoreImports": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minLength": 1,
+  "maxLength": 3
+}
+```
 <!-- End:AutoDoc -->

--- a/src/docs/rules/terMaxLenRule.md
+++ b/src/docs/rules/terMaxLenRule.md
@@ -1,0 +1,6 @@
+<!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
+## ter-max-len (ESLint: [max-len](http://eslint.org/docs/rules/max-len))
+
+enforce a maximum line length
+
+<!-- End:AutoDoc -->

--- a/src/readme/rules.ts
+++ b/src/readme/rules.ts
@@ -1912,33 +1912,7 @@ const rules: IRule[] = [
     category: 'Stylistic Issues',
     description: 'enforce consistent indentation',
     eslintUrl: 'http://eslint.org/docs/rules/indent',
-    provider: 'tslint-eslint-rules',
-    usage: `~~~json
-    "indent": [
-        true,
-        "tab"
-      ]
-    ~~~
-
-    ~~~json
-    "indent": [
-        true,
-        2
-      ]
-    ~~~
-
-    ~~~json
-    "indent": [
-        true,
-        2,
-        {
-          "FunctionExpression": {
-            "parameters": 1,
-            "body": 1
-          }
-        }
-      ]
-    ~~~`
+    provider: 'tslint-eslint-rules'
   },
   {
     available: false,

--- a/src/readme/rules.ts
+++ b/src/readme/rules.ts
@@ -17,7 +17,7 @@ interface IRule {
   eslintUrl: string;
   tslintUrl?: string;
   provider: Provider;
-  usage: string;
+  usage?: string;
   note?: string;
 }
 
@@ -2080,13 +2080,11 @@ const rules: IRule[] = [
   {
     available: true,
     eslintRule: 'max-len',
-    tslintRule: 'max-line-length',
+    tslintRule: 'ter-max-len',
     category: 'Stylistic Issues',
-    description: 'specify the maximum length of a line in your program',
+    description: 'enforce a maximum line length',
     eslintUrl: 'http://eslint.org/docs/rules/max-len',
-    tslintUrl: 'http://palantir.github.io/tslint/rules/max-line-length',
-    provider: 'native',
-    usage: ''
+    provider: 'tslint-eslint-rules'
   },
   {
     available: true,

--- a/src/rules/terIndentRule.ts
+++ b/src/rules/terIndentRule.ts
@@ -8,6 +8,7 @@
 import * as ts from 'typescript';
 import * as Lint from 'tslint/lib/lint';
 
+const RULE_NAME = 'ter-indent';
 const DEFAULT_VARIABLE_INDENT = 1;
 const DEFAULT_PARAMETER_INDENT = null;
 const DEFAULT_FUNCTION_BODY_INDENT = 1;
@@ -38,17 +39,18 @@ function isOneOf(node: ts.Node, kinds: string[]) {
 
 export class Rule extends Lint.Rules.AbstractRule {
   public static metadata: Lint.IRuleMetadata = {
-    ruleName: 'ter-indent',
+    ruleName: RULE_NAME,
     description: 'enforce consistent indentation',
     rationale: Lint.Utils.dedent`
       Using only one of tabs or spaces for indentation leads to more consistent editor behavior,
-      cleaner diffs in version control, and easier programmatic manipulation.`,
+      cleaner diffs in version control, and easier programmatic manipulation.
+      `,
     optionsDescription: Lint.Utils.dedent`
       The string 'tab' or an integer indicating the number of spaces to use per tab.
 
       An object may be provided to fine tune the indentation rules:
             
-        * \`"SwitchCase"\` (default: 0) enforces indentation level for \`case\` clauses in 
+        * \`"SwitchCase"\` (default: 0) enforces indentation level for \`case\` clauses in
                            \`switch\` statements
         * \`"VariableDeclarator"\` (default: 1) enforces indentation level for \`var\` declarators;
                                    can also take an object to define separate rules for \`var\`,
@@ -140,6 +142,24 @@ export class Rule extends Lint.Rules.AbstractRule {
       maxLength: 2
     },
     optionExamples: [
+      Lint.Utils.dedent`
+        "${RULE_NAME}": [true, "tab"]
+        `,
+      Lint.Utils.dedent`
+        "${RULE_NAME}": [true, 2]
+        `,
+      Lint.Utils.dedent`
+        "${RULE_NAME}": [
+          true,
+          2,
+          {
+            "FunctionExpression": {
+              "parameters": 1,
+              "body": 1
+            }
+          }
+        ]      
+        `
     ],
     type: 'maintainability'
   };

--- a/src/rules/terMaxLenRule.ts
+++ b/src/rules/terMaxLenRule.ts
@@ -92,7 +92,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     rationale: Lint.Utils.dedent`
       Limiting the length of a line of code improves code readability.
       It also makes comparing code side-by-side easier and improves compatibility with
-      various editors, IDEs, and diff viewers.`,
+      various editors, IDEs, and diff viewers.
+      `,
     optionsDescription: Lint.Utils.dedent`
       An integer indicating the maximum length of lines followed by an optional integer specifying
       the character width for tab characters.
@@ -160,12 +161,14 @@ export class Rule extends Lint.Rules.AbstractRule {
         additionalProperties: false
       }],
       minLength: 1,
-      maxLength: 2
+      maxLength: 3
     },
     optionExamples: [
-      '[true, 100]',
       Lint.Utils.dedent`
-        [
+        "ter-max-len": [true, 100]
+        `,
+      Lint.Utils.dedent`
+        "ter-max-len": [
           true,
           100,
           2,
@@ -173,9 +176,10 @@ export class Rule extends Lint.Rules.AbstractRule {
             "${IGNORE_URLS}": true,
             "${IGNORE_PATTERN}": "^\\\\s*(let|const)\\\\s.+=\\\\s*require\\\\s*\\\\("
           }
-        ]`,
+        ]
+        `,
       Lint.Utils.dedent`
-        [
+        "ter-max-len": [
           true,
           {
             "${CODE}": 100,
@@ -184,7 +188,8 @@ export class Rule extends Lint.Rules.AbstractRule {
             "${IGNORE_URLS}": true,
             "${IGNORE_PATTERN}": "^\\\\s*(let|const)\\\\s.+=\\\\s*require\\\\s*\\\\("
           }
-        ]`
+        ]
+        `
     ],
     type: 'style'
   };

--- a/src/rules/terMaxLenRule.ts
+++ b/src/rules/terMaxLenRule.ts
@@ -1,0 +1,440 @@
+/**
+ * This is a port of eslint:max-len.
+ *
+ * source file: https://github.com/eslint/eslint/blob/master/lib/rules/max-len.js
+ * git commit hash: 183def6115cad6f17c82ef1c1a245eb22d0bee83
+ *
+ * An addition exception has been added: ignoreImports.
+ */
+import * as ts from 'typescript';
+import * as Lint from 'tslint/lib/lint';
+
+import { IDisabledInterval } from 'tslint/lib/language/rule/rule';
+
+const CODE: string = 'code';
+const COMMENTS: string = 'comments';
+const TAB_WIDTH: string = 'tabWidth';
+const IGNORE_PATTERN: string = 'ignorePattern';
+const IGNORE_COMMENTS: string = 'ignoreComments';
+const IGNORE_STRINGS: string = 'ignoreStrings';
+const IGNORE_URLS: string = 'ignoreUrls';
+const IGNORE_TEMPLATE_LITERALS: string = 'ignoreTemplateLiterals';
+const IGNORE_REG_EXP_LITERALS: string = 'ignoreRegExpLiterals';
+const IGNORE_TRAILING_COMMENTS: string = 'ignoreTrailingComments';
+const IGNORE_IMPORTS: string = 'ignoreImports';
+
+/**
+ * Computes the length of a line that may contain tabs. The width of each tab will be the number of
+ * spaces to the next tab stop.
+ */
+function computeLineLength(line: string, tabWidth: number) {
+  let extraCharacterCount = 0;
+  line.replace(/\t/g, (match, offset) => {
+    const totalOffset = offset + extraCharacterCount;
+    const previousTabStopOffset = tabWidth ? totalOffset % tabWidth : 0;
+    const spaceCount = tabWidth - previousTabStopOffset;
+    extraCharacterCount += spaceCount - 1;  // -1 for the replaced tab
+    return '\t';
+  });
+  return line.length + extraCharacterCount;
+}
+
+/**
+ * Tells if a comment encompasses the entire line.
+ */
+function isFullLineComment(line: string, lineNumber: number, comment: INode) {
+  const start = comment.start;
+  const end = comment.end;
+  const isFirstTokenOnLine = !line.slice(0, start[1]).trim();
+
+  return comment &&
+    (start[0] < lineNumber || (start[0] === lineNumber && isFirstTokenOnLine)) &&
+    (end[0] > lineNumber || (end[0] === lineNumber && end[1] === line.length));
+}
+
+/**
+ * Tells if a given comment is trailing: it starts on the current line and extends to or past the
+ * end of the current line.
+ */
+function isTrailingComment(line: string, lineNumber: number, comment: INode) {
+  return comment &&
+    (comment.start[0] === lineNumber && lineNumber <= comment.end[0]) &&
+    (comment.end[0] > lineNumber || comment.end[1] === line.length);
+}
+
+/**
+ * Gets the line after the comment and any remaining trailing whitespace is stripped.
+ */
+function stripTrailingComment(line: string, lineNumber: number, comment: INode) {
+  return line.slice(0, comment.start[1]).replace(/\s+$/, '');
+}
+
+/**
+ * A reducer to group an AST node by line number, both start and end.
+ */
+function groupByLineNumber(acc, node: INode) {
+  const startLoc = node.start;
+  const endLoc = node.end;
+
+  for (let i = startLoc[0]; i <= endLoc[0]; ++i) {
+    if (!Array.isArray(acc[i])) {
+      acc[i] = [];
+    }
+    acc[i].push(node);
+  }
+  return acc;
+}
+
+export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'ter-max-len',
+    description: 'enforce a maximum line length',
+    rationale: Lint.Utils.dedent`
+      Limiting the length of a line of code improves code readability.
+      It also makes comparing code side-by-side easier and improves compatibility with
+      various editors, IDEs, and diff viewers.`,
+    optionsDescription: Lint.Utils.dedent`
+      An integer indicating the maximum length of lines followed by an optional integer specifying
+      the character width for tab characters.
+
+      An optional object may be provided to fine tune the rule:
+
+      * \`"${CODE}"\`: (default 80) enforces a maximum line length
+      * \`"${TAB_WIDTH}"\`: (default 4) specifies the character width for tab characters
+      * \`"${COMMENTS}"\`: enforces a maximum line length for comments; defaults to value of code
+      * \`"${IGNORE_PATTERN}"\`: ignores lines matching a regular expression; can only match a single
+                                 line and need to be double escaped when written in JSON
+      * \`"${IGNORE_COMMENTS}"\`: true ignores all trailing comments and comments on their own line
+      * \`"${IGNORE_TRAILING_COMMENTS}"\`: true ignores only trailing comments
+      * \`"${IGNORE_URLS}"\`: true ignores lines that contain a URL
+      * \`"${IGNORE_STRINGS}"\`: true ignores lines that contain a double-quoted or single-quoted string
+      * \`"${IGNORE_TEMPLATE_LITERALS}"\`: true ignores lines that contain a template literal
+      * \`"${IGNORE_REG_EXP_LITERALS}"\`: true ignores lines that contain a RegExp literal
+      * \`"${IGNORE_IMPORTS}"\`: true ignores lines that contain an import module specifier
+      `,
+    options: {
+      type: 'array',
+      items: [{
+        type: 'number',
+        minimum: '0'
+      }, {
+        type: 'object',
+        properties: {
+          [CODE]: {
+            type: 'number',
+            minumum: '1'
+          },
+          [COMMENTS]: {
+            type: 'number',
+            minumum: '1'
+          },
+          [TAB_WIDTH]: {
+            type: 'number',
+            minumum: '1'
+          },
+          [IGNORE_PATTERN]: {
+            type: 'string'
+          },
+          [IGNORE_COMMENTS]: {
+            type: 'boolean'
+          },
+          [IGNORE_STRINGS]: {
+            type: 'boolean'
+          },
+          [IGNORE_URLS]: {
+            type: 'boolean'
+          },
+          [IGNORE_TEMPLATE_LITERALS]: {
+            type: 'boolean'
+          },
+          [IGNORE_REG_EXP_LITERALS]: {
+            type: 'boolean'
+          },
+          [IGNORE_TRAILING_COMMENTS]: {
+            type: 'boolean'
+          },
+          [IGNORE_IMPORTS]: {
+            type: 'boolean'
+          }
+        },
+        additionalProperties: false
+      }],
+      minLength: 1,
+      maxLength: 2
+    },
+    optionExamples: [
+      '[true, 100]',
+      Lint.Utils.dedent`
+        [
+          true,
+          100,
+          2,
+          {
+            "${IGNORE_URLS}": true,
+            "${IGNORE_PATTERN}": "^\\\\s*(let|const)\\\\s.+=\\\\s*require\\\\s*\\\\("
+          }
+        ]`,
+      Lint.Utils.dedent`
+        [
+          true,
+          {
+            "${CODE}": 100,
+            "${TAB_WIDTH}": 2,
+            "${IGNORE_IMPORTS}": true,
+            "${IGNORE_URLS}": true,
+            "${IGNORE_PATTERN}": "^\\\\s*(let|const)\\\\s.+=\\\\s*require\\\\s*\\\\("
+          }
+        ]`
+    ],
+    type: 'style'
+  };
+
+  public static URL_REGEXP = /[^:/?#]:\/\/[^?#]/;
+
+  public static mergeOptions(options: any[]): { [key: string]: any } {
+    const optionsObj: { [key: string]: any } = {};
+    let obj = options[0];
+    if (typeof obj === 'number') {
+      optionsObj[CODE] = obj || 80;
+      obj = options[1];
+    }
+    if (typeof obj === 'number') {
+      optionsObj[TAB_WIDTH] = obj || 4;
+      obj = options[2];
+    }
+    if (typeof obj === 'object' && !Array.isArray(obj)) {
+      Object.keys(obj).forEach((key) => {
+        optionsObj[key] = obj[key];
+      });
+    }
+    optionsObj[CODE] = optionsObj[CODE] || 80;
+    optionsObj[TAB_WIDTH] = optionsObj[TAB_WIDTH] || 4;
+    return optionsObj;
+  }
+
+  public isEnabled(): boolean {
+    if (super.isEnabled()) {
+      const options = this.getOptions().ruleArguments;
+      const option = options[0];
+      if (typeof option === 'number' && option > 0) {
+        return true;
+      }
+      // Check if using objects
+      const optionsObj = Rule.mergeOptions(options);
+      if (optionsObj[CODE]) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    return this.applyWithWalker(new MaxLenWalker(sourceFile, this.getOptions()));
+  }
+}
+
+interface INode {
+  start: [number, number];
+  end: [number, number];
+  startPosition: number;
+  endPosition: number;
+  text: string;
+  kind: number;
+}
+
+class MaxLenWalker extends Lint.SkippableTokenAwareRuleWalker {
+  private ignoredIntervals: IDisabledInterval[] = [];
+  private optionsObj: { [key: string]: any } = {};
+  private comments: INode[] = [];
+  private strings: INode[] = [];
+  private templates: INode[] = [];
+  private regExp: INode[] = [];
+
+  constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
+    super(sourceFile, options);
+    this.optionsObj = Rule.mergeOptions(this.getOptions());
+  }
+
+  public hasOption(option: string): boolean {
+    if (this.optionsObj[option] && this.optionsObj[option]) {
+      return true;
+    }
+    return false;
+  }
+
+  public getOption(option: string): any {
+    return this.optionsObj[option];
+  }
+
+  protected visitStringLiteral(node: ts.StringLiteral): void {
+    this.strings.push(this.getINode(node.kind, node.getText(), node.getStart()));
+    super.visitStringLiteral(node);
+  }
+
+  protected visitRegularExpressionLiteral(node: ts.Node): void {
+    this.regExp.push(this.getINode(node.kind, node.getText(), node.getStart()));
+    super.visitRegularExpressionLiteral(node);
+  }
+
+  public getINode(kind: number, text: string, startPos: number): INode {
+    const width = text.length;
+    const src = this.getSourceFile();
+    const startLoc = src.getLineAndCharacterOfPosition(startPos);
+    const endLoc = src.getLineAndCharacterOfPosition(startPos + width);
+    return {
+      kind,
+      text,
+      startPosition: startPos,
+      endPosition: startPos + width,
+      start: [startLoc.line, startLoc.character],
+      end: [endLoc.line, endLoc.character]
+    };
+  }
+
+  public visitSourceFile(node: ts.SourceFile) {
+    super.visitSourceFile(node);
+
+    Lint.scanAllTokens(ts.createScanner(ts.ScriptTarget.ES5, false, ts.LanguageVariant.Standard, node.text), (scanner: ts.Scanner) => {
+      const token = scanner.getToken();
+      const startPos = scanner.getStartPos();
+      if (this.tokensToSkipStartEndMap[startPos]) {
+        // tokens to skip are places where the scanner gets confused about what the token is, without the proper context
+        // (specifically, regex, identifiers, and templates). So skip those tokens.
+        scanner.setTextPos(this.tokensToSkipStartEndMap[startPos]);
+        return;
+      }
+
+      if (
+        token === ts.SyntaxKind.SingleLineCommentTrivia ||
+        token === ts.SyntaxKind.MultiLineCommentTrivia
+      ) {
+        this.comments.push(this.getINode(token, scanner.getTokenText(), startPos));
+      } else if (token === ts.SyntaxKind.FirstTemplateToken) {
+        this.templates.push(this.getINode(token, scanner.getTokenText(), startPos));
+      }
+    });
+    // We should have all the ignored intervals, comments, strings, templates, etc...
+    // lets find those long lines
+    this.findFailures(node);
+  }
+
+  protected visitImportDeclaration(node: ts.ImportDeclaration) {
+    super.visitImportDeclaration(node);
+    /* We only care to see the module specifier, not the whole import declaration. This covers
+     the following case:
+
+     import {
+     ...
+     } from 'this is the module specifier, this line should be ignored only, not the rest of the import';
+
+     */
+    const startPos = node.moduleSpecifier.getStart();
+    const text = node.moduleSpecifier.getText();
+    const width = text.length;
+    if (this.hasOption(IGNORE_IMPORTS)) {
+      this.ignoredIntervals.push({
+        endPosition: startPos + width,
+        startPosition: startPos
+      });
+    }
+  }
+
+  public findFailures(sourceFile: ts.SourceFile) {
+    const lineStarts = sourceFile.getLineStarts();
+    const source = sourceFile.getFullText();
+
+    const lineLimit = this.getOption(CODE) || 80;
+    const ignoreTrailingComments = this.getOption(IGNORE_TRAILING_COMMENTS) ||
+      this.getOption(IGNORE_COMMENTS) ||
+      false;
+    const ignoreComments = this.getOption(IGNORE_COMMENTS) || false;
+    const ignoreStrings = this.getOption(IGNORE_STRINGS) || false;
+    const ignoreTemplateLiterals = this.getOption(IGNORE_TEMPLATE_LITERALS) || false;
+    const ignoreUrls = this.getOption(IGNORE_URLS) || false;
+    const ignoreRexExpLiterals = this.getOption(IGNORE_REG_EXP_LITERALS) || false;
+    const pattern = this.getOption(IGNORE_PATTERN) || null;
+    const tabWidth = this.getOption(TAB_WIDTH) || 4;
+    const maxCommentLength = this.getOption(COMMENTS);
+
+    const comments = ignoreComments || maxCommentLength || ignoreTrailingComments ? this.comments : [];
+
+    let commentsIndex = 0;
+    const stringsByLine = this.strings.reduce(groupByLineNumber, {});
+    const templatesByLine = this.templates.reduce(groupByLineNumber, {});
+    const regExpByLine = this.regExp.reduce(groupByLineNumber, {});
+    const totalLines = lineStarts.length;
+
+    for (let i = 0; i < totalLines; ++i) {
+      const from = lineStarts[i];
+      const to = lineStarts[i + 1];
+      let line = source.substring(from, i === totalLines - 1 ? to : to - 1);
+      let lineIsComment = false;
+
+      /*
+       * We can short-circuit the comment checks if we're already out of
+       * comments to check.
+       */
+      if (commentsIndex < comments.length) {
+        let comment = null;
+
+        // iterate over comments until we find one past the current line
+        do {
+          comment = comments[++commentsIndex];
+        } while (comment && comment.start[0] <= i);
+
+        // and step back by one
+        comment = comments[--commentsIndex];
+
+        if (isFullLineComment(line, i, comment)) {
+          lineIsComment = true;
+        } else if (ignoreTrailingComments && isTrailingComment(line, i, comment)) {
+          line = stripTrailingComment(line, i, comment);
+        }
+      }
+
+      if (
+        ignoreUrls && Rule.URL_REGEXP.test(line) ||
+        pattern && new RegExp(pattern).test(line) ||
+        ignoreStrings && stringsByLine[i] ||
+        ignoreTemplateLiterals && templatesByLine[i] ||
+        ignoreRexExpLiterals && regExpByLine[i]
+      ) {
+        // ignore this line
+        continue;
+      }
+
+      const lineLength = computeLineLength(line, tabWidth);
+      if (lineIsComment && ignoreComments) {
+        continue;
+      }
+
+      let ruleFailure: Lint.RuleFailure;
+      if (lineIsComment && exceedLineLimit(lineLength, maxCommentLength, source[to - 2])) {
+        ruleFailure = new Lint.RuleFailure(
+          sourceFile, from, to - 1,
+          `Line ${i} exceeds the maximum comment line length of ${maxCommentLength}.`,
+          this.getOptions().ruleName
+        );
+      } else if (exceedLineLimit(lineLength, lineLimit, source[to - 2])) {
+        ruleFailure = new Lint.RuleFailure(
+          sourceFile, from, to - 1,
+          `Line ${i} exceeds the maximum line length of ${lineLimit}.`,
+          this.getOptions().ruleName
+        );
+      }
+
+      if (ruleFailure && !Lint.doesIntersect(ruleFailure, this.ignoredIntervals)) {
+        this.addFailure(ruleFailure);
+      }
+    }
+  }
+}
+
+function exceedLineLimit(lineLength: number, lineLimit: number, secondToLast: string): boolean {
+  // first condition is whether the line is larger than the line limit
+  // second to check for windows line endings, that is, check to make sure it is not the case
+  // that we are only over by the limit by exactly one and that the character we are over the
+  // limit by is a '\r' character which does not count against the limit
+  // (and thus we are not actually over the limit).
+  return lineLength > lineLimit && !((lineLength - 1) === lineLimit && secondToLast === '\r');
+}

--- a/src/test/rules/terMaxLenRuleTests.ts
+++ b/src/test/rules/terMaxLenRuleTests.ts
@@ -1,0 +1,401 @@
+/// <reference path='../../../typings/mocha/mocha.d.ts' />
+import * as Lint from 'tslint/lib/lint';
+import { runTest, IScripts, IScriptError } from './helper';
+
+function expectedErrors(errors: [[number, number] | [number, number, boolean]]): IScriptError[] {
+  return errors.map((err) => {
+    let message = `Line ${err[0]} exceeds the maximum line length of ${err[1]}.`;
+    if (err[2]) {
+      message = `Line ${err[0]} exceeds the maximum comment line length of ${err[1]}.`;
+    }
+
+    return { message, line: err[0] };
+  });
+}
+
+/**
+ * Borrowing tests from eslint:
+ *    https://github.com/eslint/eslint/blob/master/tests/lib/rules/max-len.js
+ */
+const rule = 'ter-max-len';
+const scripts: { valid: IScripts, invalid: IScripts } = {
+  valid: [
+    {
+      code: Lint.Utils.dedent`
+        var dep = require('really/really/really/really/really/really/really/long/module');
+        const dep = require('another/really/really/really/really/really/really/long/module');
+                         foobar = 'this line will be ignored because it starts with foobar ...';
+        `,
+      options: [50, { ignorePattern: '^\\s*(var|const)\\s.+=\\s*require\\s*\\(|^\\s*foobar' }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        import { obj1, obj2, obj3, obj4 } from 'my-favorite-module/with/lots/of/deep/nested/modules';
+        import {
+            obj1,
+            obj2,
+            obj3,
+            obj4,
+        } from 'my-favorite-module/with/lots/of/deep/nested/modules';
+        `,
+      options: [50, { ignoreImports: true }]
+    },
+    {
+      code: 'var x = 5;\nvar x = 2;'
+    },
+    {
+      code: 'var x = 5;\nvar x = 2;',
+      options: [80]
+    },
+    {
+      code: 'var one\t\t= 1;\nvar three\t= 3;',
+      options: [16, 4]
+    },
+    {
+      code: '\tvar one\t\t= 1;\n\tvar three\t= 3;',
+      options: [20, 4]
+    },
+    {
+      code: 'var i = 1;\r\nvar i = 1;\n',
+      options: [10, 4]
+    },
+    {
+      code: '\n// Blank line on top\nvar foo = module.exports = {};\n',
+      options: [80, 4]
+    },
+    {
+      code: '\n// Blank line on top\nvar foo = module.exports = {};\n'
+    },
+    {
+      code: 'var foo = module.exports = {}; // really long trailing comment',
+      options: [40, 4, { ignoreComments: true }]
+    }, {
+      code: 'foo(); \t// strips entire comment *and* trailing whitespace',
+      options: [6, 4, { ignoreComments: true }]
+    }, {
+      code: '// really long comment on its own line sitting here',
+      options: [40, 4, { ignoreComments: true }]
+    },
+    {
+      code: 'var /*inline-comment*/ i = 1;'
+    },
+    {
+      code: 'var /*inline-comment*/ i = 1; // with really long trailing comment',
+      options: [40, 4, { ignoreComments: true }]
+    }, {
+      code: `foo('http://example.com/this/is/?a=longish&url=in#here');`,
+      options: [40, 4, { ignoreUrls: true }]
+    }, {
+      code: "foo(bar(bazz('this is a long'), 'line of'), 'stuff');",
+      options: [40, 4, { ignorePattern: 'foo.+bazz\\(' }]
+    }, {
+      code: Lint.Utils.dedent`
+        /* hey there! this is a multiline
+           comment with longish lines in various places
+           but
+           with a short line-length */`,
+      options: [10, 4, { ignoreComments: true }]
+    }, {
+      code: Lint.Utils.dedent`
+        // I like short comments
+        function butLongSourceLines() { weird(eh()) }`,
+      options: [80, {tabWidth: 4, comments: 30}]
+    }, {
+      code: Lint.Utils.dedent`
+        // Full line comment
+        someCode(); // With a long trailing comment.`,
+      options: [{ code: 30, tabWidth: 4, comments: 20, ignoreTrailingComments: true }]
+    }, {
+      code: 'var foo = module.exports = {}; // really long trailing comment',
+      options: [40, 4, { ignoreTrailingComments: true }]
+    }, {
+      code: 'var foo = module.exports = {}; // really long trailing comment',
+      options: [40, 4, { ignoreComments: true, ignoreTrailingComments: false }]
+    },
+    // ignoreStrings, ignoreTemplateLiterals and ignoreRegExpLiterals options
+    {
+      code: `var foo = veryLongIdentifier;\nvar bar = 'this is a very long string';`,
+      options: [29, 4, { ignoreStrings: true }]
+    },
+    {
+      code: `var foo = veryLongIdentifier;\nvar bar = "this is a very long string";`,
+      options: [29, 4, { ignoreStrings: true }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var str = "this is a very long string\
+        with continuation";`,
+      options: [29, 4, { ignoreStrings: true }]
+    },
+    {
+      code: 'var str = \"this is a very long string\\\nwith continuation\\\nand with another very very long continuation\\\nand ending\";',
+      options: [29, 4, { ignoreStrings: true }]
+    },
+    {
+      code: 'var foo = veryLongIdentifier;\nvar bar = `this is a very long string`;',
+      options: [29, 4, { ignoreTemplateLiterals: true }]
+    },
+    {
+      code: 'var foo = veryLongIdentifier;\nvar bar = `this is a very long string\nand this is another line that is very long`;',
+      options: [29, 4, { ignoreTemplateLiterals: true }]
+    },
+    {
+      code: Lint.Utils.dedent`
+        var foo = veryLongIdentifier;
+        var bar = \`this is a very long string
+        and this is another line that is very long
+        and here is another
+         and another!\`;`,
+      options: [29, 4, { ignoreTemplateLiterals: true }]
+    },
+    {
+      code: 'var foo = /this is a very long pattern/;',
+      options: [29, 4, { ignoreRegExpLiterals: true }]
+    },
+    // check indented comment lines - https://github.com/eslint/eslint/issues/6322
+    {
+      code: Lint.Utils.dedent`
+        function foo() {
+        //this line has 29 characters
+        }`,
+      options: [40, 4, { comments: 29 }]
+    }, {
+      code: Lint.Utils.dedent`
+        function foo() {
+            //this line has 33 characters
+        }`,
+      options: [40, 4, { comments: 33 }]
+    }, {
+      code: Lint.Utils.dedent`
+        function foo() {
+        /*this line has 29 characters
+        and this one has 21*/
+        }`,
+      options: [40, 4, { comments: 29 }]
+    }, {
+      code: Lint.Utils.dedent`
+        function foo() {
+            /*this line has 33 characters
+            and this one has 25*/
+        }`,
+      options: [40, 4, { comments: 33 }]
+    }, {
+      code: Lint.Utils.dedent`
+        function foo() {
+            var a; /*this line has 40 characters
+            and this one has 36 characters*/
+        }`,
+      options: [40, 4, { comments: 36 }]
+    }, {
+      code: Lint.Utils.dedent`
+        function foo() {
+            /*this line has 33 characters
+            and this one has 43 characters*/ var a;
+        }`,
+      options: [43, 4, { comments: 33 }]
+    },
+    {
+      code: ''
+    }
+  ],
+  invalid: [
+    {
+      code: Lint.Utils.dedent`
+        import {
+          obj1, obj2, obj3, obj4, just, trying, to, be, a, rebel, here
+        } from 'my-favorite-module/with/lots/of/deep/nested/modules';
+        `,
+      options: [50, { ignoreImports: true }],
+      errors: expectedErrors([[2, 50]])
+    },
+    {
+      code: '\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tvar i = 1;',
+      errors: expectedErrors([[0, 80]])
+    },
+    {
+      code: 'var x = 5, y = 2, z = 5;',
+      options: [10],
+      errors: expectedErrors([[0, 10]])
+    },
+    {
+      code: '\t\t\tvar i = 1;',
+      options: [15],
+      errors: expectedErrors([[0, 15]])
+    },
+    {
+      code: '\t\t\tvar i = 1;\n\t\t\tvar j = 1;',
+      options: [15, { tabWidth: 4 }],
+      errors: expectedErrors([[0, 15], [1, 15]])
+    },
+    {
+      code: 'var /*this is a long non-removed inline comment*/ i = 1;',
+      options: [20, { tabWidth: 4, ignoreComments: true }],
+      errors: expectedErrors([[0, 20]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var foobar = 'this line isn\\'t matched by the regexp';
+        var fizzbuzz = 'but this one is matched by the regexp';
+        `,
+      options: [20, 4, { ignorePattern: 'fizzbuzz' }],
+      errors: expectedErrors([[1, 20]])
+    },
+    {
+      code: `var longLine = 'will trigger'; // even with a comment`,
+      options: [10, 4, { ignoreComments: true }],
+      errors: expectedErrors([[0, 10]])
+    },
+    {
+      code: `var foo = module.exports = {}; // really long trailing comment`,
+      options: [40, 4],  // ignoreComments is disabled
+      errors: expectedErrors([[0, 40]])
+    },
+    {
+      code: `foo('http://example.com/this/is/?a=longish&url=in#here');`,
+      options: [40, 4],  // ignoreUrls is disabled
+      errors: expectedErrors([[0, 40]])
+    },
+    {
+      code: `foo(bar(bazz('this is a long'), 'line of'), 'stuff');`,
+      options: [40, 4],  // ignorePattern is disabled
+      errors: expectedErrors([[0, 40]])
+    },
+    {
+      code: '// A comment that exceeds the max comment length.',
+      options: [80, 4, { comments: 20 }],
+      errors: expectedErrors([[0, 20, true]])
+    },
+    {
+      code: '// A comment that exceeds the max comment length.',
+      options: [{ code: 20 }],
+      errors: expectedErrors([[0, 20]])
+    },
+    {
+      code: '//This is very long comment with more than 40 characters which is invalid',
+      options: [40, 4, { ignoreTrailingComments: true }],
+      errors: expectedErrors([[0, 40]])
+    },
+    // check indented comment lines - https://github.com/eslint/eslint/issues/6322
+    {
+      code: Lint.Utils.dedent`
+        function foo() {
+        //this line has 29 characters
+        }`,
+      options: [40, 4, { comments: 28 }],
+      errors: expectedErrors([[2, 28, true]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo() {
+            //this line has 33 characters
+        }`,
+      options: [40, 4, { comments: 32 }],
+      errors: expectedErrors([[2, 32, true]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo() {
+        /*this line has 29 characters
+        and this one has 32 characters*/
+        }`,
+      options: [40, 4, { comments: 28 }],
+      errors: expectedErrors([
+        [2, 28, true],
+        [3, 28, true]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo() {
+            /*this line has 33 characters
+            and this one has 36 characters*/
+        }`,
+      options: [40, 4, { comments: 32 }],
+      errors: expectedErrors([
+        [2, 32, true],
+        [3, 32, true]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo() {
+            var a; /*this line has 40 characters
+            and this one has 36 characters*/
+        }`,
+      options: [39, 4, { comments: 35 }],
+      errors: expectedErrors([
+        [2, 39],
+        [3, 35, true]
+      ])
+    },
+    {
+      code: Lint.Utils.dedent`
+        function foo() {
+            /*this line has 33 characters
+            and this one has 43 characters*/ var a;
+        }`,
+      options: [42, 4, { comments: 32 }],
+      errors: expectedErrors([
+        [2, 32, true],
+        [3, 42]
+      ])
+    },
+    // check comments with the same length as non-comments - https://github.com/eslint/eslint/issues/6564
+    {
+      code:  Lint.Utils.dedent`
+        // This commented line has precisely 51 characters.
+        var x = 'This line also has exactly 51 characters';`,
+      options: [20, { ignoreComments: true }],
+      errors: expectedErrors([[2, 20]])
+    },
+    // ignoreStrings and ignoreTemplateLiterals options
+    {
+      code: `var foo = veryLongIdentifier;\nvar bar = 'this is a very long string';`,
+      options: [29, { ignoreStrings: false, ignoreTemplateLiterals: true }],
+      errors: expectedErrors([[1, 29]])
+    },
+    {
+      code: `var foo = veryLongIdentifier;\nvar bar = /this is a very very long pattern/;`,
+      options: [29, { ignoreStrings: false, ignoreRegExpLiterals: false }],
+      errors: expectedErrors([[1, 29]])
+    },
+    {
+      code: `var foo = veryLongIdentifier;\nvar bar = new RegExp('this is a very very long pattern');`,
+      options: [29, { ignoreStrings: false, ignoreRegExpLiterals: true }],
+      errors: expectedErrors([[1, 29]])
+    },
+    {
+      code: `var foo = veryLongIdentifier;\nvar bar = \"this is a very long string\";`,
+      options: [29, { ignoreStrings: false, ignoreTemplateLiterals: true }],
+      errors: expectedErrors([[1, 29]])
+    },
+    {
+      code: 'var foo = veryLongIdentifier;\nvar bar = `this is a very long string`;',
+      options: [29, { ignoreStrings: false, ignoreTemplateLiterals: false }],
+      errors: expectedErrors([[1, 29]])
+    },
+    {
+      code: Lint.Utils.dedent`
+        var foo = veryLongIdentifier;
+        var bar = \`this is a very long string
+        and this is another line that is very long\`;`,
+      options: [29, { ignoreStrings: false, ignoreTemplateLiterals: false }],
+      errors: expectedErrors([
+        [2, 29],
+        [3, 29]
+      ])
+    }
+  ]
+};
+
+describe(rule, () => {
+
+  it('should pass when the line lengths complies with the rule', () => {
+    runTest(rule, scripts.valid);
+  });
+
+  it('should fail when the line length exceeds the limit imposed', () => {
+    runTest(rule, scripts.invalid);
+  });
+
+});


### PR DESCRIPTION
Please merge the `ter-indent` PR before doing a code review on this one. This PR is a branch of the other one since I needed the modifications to the test helper file.

In this PR I have generated the documentation for `ter-max-len` and `ter-indent` from the rule metadata. This means that we now only have to worry about keeping the rule up to date and the documentation will reflect it. We can of course still add more content to the documentation if we want (special notes perhaps that may not be relevant to rule file perhaps).