### PR TITLE
[fix] ter-max-len

### DIFF
--- a/src/rules/terMaxLenRule.ts
+++ b/src/rules/terMaxLenRule.ts
@@ -417,14 +417,14 @@ class MaxLenWalker extends Lint.SkippableTokenAwareRuleWalker {
       if (lineIsComment && exceedLineLimit(lineLength, maxCommentLength, source[to - 2])) {
         ruleFailure = new Lint.RuleFailure(
           sourceFile, from, to - 1,
-          `Line ${i} exceeds the maximum comment line length of ${maxCommentLength}.`,
-          this.getOptions().ruleName
+          `Line ${i + 1} exceeds the maximum comment line length of ${maxCommentLength}.`,
+          Rule.metadata.ruleName
         );
       } else if (exceedLineLimit(lineLength, lineLimit, source[to - 2])) {
         ruleFailure = new Lint.RuleFailure(
           sourceFile, from, to - 1,
-          `Line ${i} exceeds the maximum line length of ${lineLimit}.`,
-          this.getOptions().ruleName
+          `Line ${i + 1} exceeds the maximum line length of ${lineLimit}.`,
+          Rule.metadata.ruleName
         );
       }
 

--- a/src/rules/terMaxLenRule.ts
+++ b/src/rules/terMaxLenRule.ts
@@ -11,6 +11,7 @@ import * as Lint from 'tslint/lib/lint';
 
 import { IDisabledInterval } from 'tslint/lib/language/rule/rule';
 
+const RULE_NAME = 'ter-max-len';
 const CODE: string = 'code';
 const COMMENTS: string = 'comments';
 const TAB_WIDTH: string = 'tabWidth';
@@ -87,7 +88,7 @@ function groupByLineNumber(acc, node: INode) {
 
 export class Rule extends Lint.Rules.AbstractRule {
   public static metadata: Lint.IRuleMetadata = {
-    ruleName: 'ter-max-len',
+    ruleName: RULE_NAME,
     description: 'enforce a maximum line length',
     rationale: Lint.Utils.dedent`
       Limiting the length of a line of code improves code readability.
@@ -165,10 +166,10 @@ export class Rule extends Lint.Rules.AbstractRule {
     },
     optionExamples: [
       Lint.Utils.dedent`
-        "ter-max-len": [true, 100]
+        "${RULE_NAME}": [true, 100]
         `,
       Lint.Utils.dedent`
-        "ter-max-len": [
+        "${RULE_NAME}": [
           true,
           100,
           2,
@@ -179,7 +180,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ]
         `,
       Lint.Utils.dedent`
-        "ter-max-len": [
+        "${RULE_NAME}": [
           true,
           {
             "${CODE}": 100,
@@ -418,13 +419,13 @@ class MaxLenWalker extends Lint.SkippableTokenAwareRuleWalker {
         ruleFailure = new Lint.RuleFailure(
           sourceFile, from, to - 1,
           `Line ${i + 1} exceeds the maximum comment line length of ${maxCommentLength}.`,
-          Rule.metadata.ruleName
+          RULE_NAME
         );
       } else if (exceedLineLimit(lineLength, lineLimit, source[to - 2])) {
         ruleFailure = new Lint.RuleFailure(
           sourceFile, from, to - 1,
           `Line ${i + 1} exceeds the maximum line length of ${lineLimit}.`,
-          Rule.metadata.ruleName
+          RULE_NAME
         );
       }
 

--- a/src/test/rules/terMaxLenRuleTests.ts
+++ b/src/test/rules/terMaxLenRuleTests.ts
@@ -4,9 +4,9 @@ import { runTest, IScripts, IScriptError } from './helper';
 
 function expectedErrors(errors: [[number, number] | [number, number, boolean]]): IScriptError[] {
   return errors.map((err) => {
-    let message = `Line ${err[0]} exceeds the maximum line length of ${err[1]}.`;
+    let message = `Line ${err[0] + 1} exceeds the maximum line length of ${err[1]}.`;
     if (err[2]) {
-      message = `Line ${err[0]} exceeds the maximum comment line length of ${err[1]}.`;
+      message = `Line ${err[0] + 1} exceeds the maximum comment line length of ${err[1]}.`;
     }
 
     return { message, line: err[0] };


### PR DESCRIPTION
Fixing issues with IDEs being not able to report a failure due to the missing rule name. This also fixes the failure message reporting the incorrect line number.