### PR TITLE
[fix] handle-callback-err (closes #146)

### DIFF
--- a/src/docs/rules/handleCallbackErrRule.md
+++ b/src/docs/rules/handleCallbackErrRule.md
@@ -3,13 +3,54 @@
 
 enforce error handling in callbacks
 
-### Usage
+#### Rationale
+
+In Node.js, a common pattern for dealing with asynchronous behavior is called the callback
+pattern. This pattern expects an Error object or null as the first argument of the callback.
+Forgetting to handle these errors can lead to some really strange behavior in your
+application.
+
+### Config
+
+The rule takes a single string option: the name of the error parameter. The default is
+`"err"`.
+
+Sometimes the name of the error variable is not consistent across the project, so you need a
+more flexible configuration to ensure that the rule reports all unhandled errors.
+
+If the configured name of the error variable begins with a `^` it is considered to be a
+regexp pattern.
+
+- If the option is `"^(err|error|anySpecificError)$"`, the rule reports unhandled errors
+  where the parameter name can be `err`, `error` or `anySpecificError`.
+- If the option is `"^.+Error$"`, the rule reports unhandled errors where the parameter
+  name ends with `Error` (for example, `connectionError` or `validationError` will
+  match).
+- If the option is `"^.*(e|E)rr"`, the rule reports unhandled errors where the parameter
+  name matches any string that contains `err` or `Err` (for example, `err`, `error`,
+  `anyError`, `some_err` will match).
+
+#### Examples
 
 ```json
-"handle-callback-err": [
-    true,
-    "^(err|error|anySpecificError)$"
-  ]
-```
+"handle-callback-err": [true, "error"]
+      ```
 
+```json
+"handle-callback-err": [true, "^(err|error|anySpecificError)$"]
+      ```
+#### Schema
+
+```json
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "string"
+    }
+  ],
+  "minLength": 0,
+  "maxLength": 1
+}
+```
 <!-- End:AutoDoc -->

--- a/src/readme/rules.ts
+++ b/src/readme/rules.ts
@@ -1467,13 +1467,7 @@ const rules: IRule[] = [
     category: 'Node.js and CommonJS',
     description: 'enforce error handling in callbacks',
     eslintUrl: 'http://eslint.org/docs/rules/handle-callback-err',
-    provider: 'tslint-eslint-rules',
-    usage: `~~~json
-    "handle-callback-err": [
-        true,
-        "^(err|error|anySpecificError)$"
-      ]
-    ~~~`
+    provider: 'tslint-eslint-rules'
   },
   {
     available: false,

--- a/src/rules/handleCallbackErrRule.ts
+++ b/src/rules/handleCallbackErrRule.ts
@@ -1,7 +1,56 @@
 import * as ts from 'typescript';
 import * as Lint from 'tslint';
 
+const RULE_NAME = 'handle-callback-err';
+
 export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: RULE_NAME,
+    description: 'enforce error handling in callbacks',
+    rationale: Lint.Utils.dedent`
+      In Node.js, a common pattern for dealing with asynchronous behavior is called the callback
+      pattern. This pattern expects an Error object or null as the first argument of the callback.
+      Forgetting to handle these errors can lead to some really strange behavior in your
+      application.
+      `,
+    optionsDescription: Lint.Utils.dedent`
+      The rule takes a single string option: the name of the error parameter. The default is
+      \`"err"\`.
+      
+      Sometimes the name of the error variable is not consistent across the project, so you need a
+      more flexible configuration to ensure that the rule reports all unhandled errors.
+
+      If the configured name of the error variable begins with a \`^\` it is considered to be a
+      regexp pattern.
+
+      - If the option is \`"^(err|error|anySpecificError)$"\`, the rule reports unhandled errors
+        where the parameter name can be \`err\`, \`error\` or \`anySpecificError\`.
+      - If the option is \`"^.+Error$"\`, the rule reports unhandled errors where the parameter
+        name ends with \`Error\` (for example, \`connectionError\` or \`validationError\` will
+        match).
+      - If the option is \`"^.*(e|E)rr"\`, the rule reports unhandled errors where the parameter
+        name matches any string that contains \`err\` or \`Err\` (for example, \`err\`, \`error\`,
+        \`anyError\`, \`some_err\` will match).
+      `,
+    options: {
+      type: 'array',
+      items: [{
+        type: 'string'
+      }],
+      minLength: 0,
+      maxLength: 1
+    },
+    optionExamples: [
+      Lint.Utils.dedent`
+        "${RULE_NAME}": [true, "error"]
+      `,
+      Lint.Utils.dedent`
+        "${RULE_NAME}": [true, "^(err|error|anySpecificError)$"]
+      `
+    ],
+    typescriptOnly: false,
+    type: 'maintainability'
+  };
   public static FAILURE_STRING = 'Expected error to be handled';
 
   public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {

--- a/src/rules/handleCallbackErrRule.ts
+++ b/src/rules/handleCallbackErrRule.ts
@@ -5,18 +5,22 @@ export class Rule extends Lint.Rules.AbstractRule {
   public static FAILURE_STRING = 'Expected error to be handled';
 
   public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-    const languageService = Lint.createLanguageService(sourceFile.fileName, sourceFile.getFullText());
-    return this.applyWithWalker(new ErrCallbackHandlerWalker(sourceFile, this.getOptions(), languageService));
+    return this.applyWithWalker(new ErrCallbackHandlerWalker(sourceFile, this.getOptions()));
   }
 }
 
-class ErrCallbackHandlerWalker extends Lint.RuleWalker {
-  private languageService: ts.LanguageService;
-  private errorCheck: (name: string) => boolean;
+interface IFunctionScope {
+  firstParamName: string | undefined;
+  hasFirstParam: boolean;
+}
 
-  constructor(sourceFile: ts.SourceFile, options: Lint.IOptions, languageService: ts.LanguageService) {
+class ErrCallbackHandlerWalker extends Lint.RuleWalker {
+  private stack: IFunctionScope[] = [];
+  private errorCheck: (name: string) => boolean;
+  private firstParameterName: (node: ts.FunctionLikeDeclaration) => string | undefined;
+
+  constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
     super(sourceFile, options);
-    this.languageService = languageService;
     const errorArgument = options.ruleArguments[0] || 'err';
 
     if (errorArgument.charAt(0) === '^') {
@@ -24,33 +28,95 @@ class ErrCallbackHandlerWalker extends Lint.RuleWalker {
     } else {
       this.errorCheck = (name) => name === errorArgument;
     }
+    this.firstParameterName = (node: ts.FunctionLikeDeclaration) => {
+      const param = node.parameters[0];
+      return param ? param.name.getText(sourceFile) : undefined;
+    };
   }
 
-  public visitFunctionExpression(node: ts.FunctionExpression) {
-    this.validateFunction(node);
-    super.visitFunctionExpression(node);
+  /**
+   * Pushes new function scope with its first parameter name and the assumption that it is not
+   * used in its body.
+   */
+  private enterScope(firstParamName?: string): void {
+    this.stack.push({
+      firstParamName,
+      hasFirstParam: false
+    });
   }
 
-  public visitFunctionDeclaration(node: ts.FunctionDeclaration) {
-    this.validateFunction(node);
+  /**
+   * Pops a function scope from the stack.
+   */
+  private exitScope(): IFunctionScope {
+    return this.stack.pop();
+  }
+
+  protected visitSourceFile(node: ts.SourceFile) {
+    // Reset internal state.
+    this.stack = [];
+    super.visitSourceFile(node);
+  }
+
+  protected visitFunctionDeclaration(node: ts.FunctionDeclaration) {
+    this.enterScope(this.firstParameterName(node));
     super.visitFunctionDeclaration(node);
+    this.exitFunction(node);
+  }
+
+  protected visitFunctionExpression(node: ts.FunctionExpression) {
+    this.enterScope(this.firstParameterName(node));
+    super.visitFunctionExpression(node);
+    this.exitFunction(node);
   }
 
   public visitArrowFunction(node: ts.ArrowFunction) {
-    this.validateFunction(node);
+    this.enterScope(this.firstParameterName(node));
     super.visitArrowFunction(node);
+    this.exitFunction(node);
   }
 
-  private validateFunction(node: ts.FunctionLikeDeclaration) {
-    const parameter = node.parameters[0];
+  protected visitCatchClause(node: ts.CatchClause) {
+    // A catch clause creates another scope in which the first paramter of the parent function
+    // may no longer be valid. Lets create another scope
+    this.enterScope(node.variableDeclaration ? node.variableDeclaration.name.getText() : undefined);
+    super.visitCatchClause(node);
+    // Just exit the scope since this is not a function
+    this.exitScope();
+  }
 
-    if (parameter && this.errorCheck(parameter.name.getText())) {
-      const fileName = this.getSourceFile().fileName;
-      const highlights = this.languageService.getDocumentHighlights(fileName, parameter.pos, [fileName]);
+  private exitFunction(node: ts.FunctionLikeDeclaration) {
+    const scopeInfo = this.exitScope();
+    const param = scopeInfo.firstParamName;
+    if (param && this.errorCheck(param) && !scopeInfo.hasFirstParam) {
+      const name = node.parameters[0].name;
+      const failure = this.createFailure(
+        name.getStart(this.getSourceFile()),
+        name.getWidth(this.getSourceFile()),
+        Rule.FAILURE_STRING
+      );
+      this.addFailure(failure);
+    }
+  }
 
-      if (!highlights || highlights[0].highlightSpans.length <= 1) {
-        this.addFailure(this.createFailure(parameter.name.getStart(), parameter.name.getWidth(), Rule.FAILURE_STRING));
+  protected visitNode(node: ts.Node) {
+    if (
+      this.stack.length > 0 &&
+      node.parent.kind !== ts.SyntaxKind.Parameter &&
+      node.kind === ts.SyntaxKind.Identifier
+    ) {
+      const text = (node as ts.Identifier).text;
+      // traverse through the function scopes (starting with the inner most)
+      // until we see one function that uses the current identifier
+      let i = this.stack.length;
+      while (i--) {
+        const info = this.stack[i];
+        if (text === info.firstParamName) {
+          info.hasFirstParam = true;
+          break;
+        }
       }
     }
+    super.visitNode(node);
   }
 }

--- a/src/test/rules/handleCallbackErrRuleTests.ts
+++ b/src/test/rules/handleCallbackErrRuleTests.ts
@@ -93,6 +93,17 @@ ruleTester.addTestGroup('custom-error-regex-pass', 'should pass with custom erro
   {
     code: `function(errorMsg, stream) { console.error(errorMsg) }`,
     options: ['^(err|error|errorMsg)$']
+  },
+  {
+    code: dedent`
+      function query (cb) {
+        doThing(function (err) {
+          closeConnection(function (closeErr) {
+            cb(err || closeErr)
+          })
+        })
+      }`,
+    options: ['^(err|closeErr)$']
   }
 ]);
 

--- a/src/test/rules/handleCallbackErrRuleTests.ts
+++ b/src/test/rules/handleCallbackErrRuleTests.ts
@@ -1,94 +1,101 @@
-/// <reference path='../../../typings/mocha/mocha.d.ts' />
-import { makeTest } from './helper';
+import { RuleTester, Failure, Position, dedent } from './ruleTester';
+// ESLint Tests: https://github.com/eslint/eslint/blob/master/tests/lib/rules/handle-callback-err.js
 
-const rule = 'handle-callback-err';
-const scripts = {
-  standardConfig: {
-    valid: [
-      'function(stream) {}',
-      `function loadData (err, data) {
-        if (err) {
-            console.log(err.stack);
-        }
-        doSomething();
-      }`,
-      `function loadData (Err, data) {
-        if (Err) {
-            console.log(Err.stack);
-        }
-        doSomething();
-      }`,
-      `function test (cb) {
-        doSomething(function (err) {
-          cb(err)
-        })
-      }`,
-      `function handle (arg, err) {}`
-    ],
-    invalid: [
-      `function(err, stream) { stream.on('done', function(){exit(0)} }`,
-      `function loadData (err, data) { doSomething(); }`,
-      `test(function (err) {
-        console.log('hello world')
-      })`,
-      `test(err => undefined)`,
-      `const cb = (err) => null`,
-      `var cb = function (err) {}`,
-      `function loadData (err, data) {
-        if (error) {
-            console.log(error.stack);
-        }
-        doSomething();
-      }`
-    ]
-  },
-  customErrorNameConfig: {
-    valid: [
-      `function(errorMsg, stream) { console.error(errorMsg) }`,
-      `function(err, stream) { }`
-    ],
-    invalid: [
-      `function(errorMsg, stream) { }`
-    ]
-  },
-  customErrorRegexConfig: {
-    valid: [
-      `function(errorMsg, stream) { console.error(errorMsg) }`
-    ],
-    invalid: [
-      `function(err, stream) { }`,
-      `function(error, stream) { }`,
-      `function(errorMsg, stream) { }`
-    ]
-  }
+const ruleTester = new RuleTester('handle-callback-err');
+
+const error: Failure = {
+  failure: 'Expected error to be handled',
+  startPosition: new Position(),
+  endPosition: new Position()
 };
 
-describe(rule, function test() {
-  const standardConfig = { rules: { 'handle-callback-err': [true] } };
-  const customErrorNameConfig = { rules: { 'handle-callback-err': [true, 'errorMsg'] } };
-  const customErrorRegexConfig = { rules: { 'handle-callback-err': [true, '^(err|error|errorMsg)$'] } };
+ruleTester.addTestGroup('standard-pass', 'should pass with standard config', [
+  'function(stream) {}',
+  dedent`
+    function loadData (err, data) {
+      if (err) {
+          console.log(err.stack);
+      }
+      doSomething();
+    }`,
+  dedent`
+    function loadData (Err, data) {
+      if (Err) {
+          console.log(Err.stack);
+      }
+      doSomething();
+    }`,
+  dedent`
+    function test (cb) {
+      doSomething(function (err) {
+        cb(err)
+      })
+    }`,
+  `function handle (arg, err) {}`
+]);
 
-  it('should pass with standard config', function testVariables() {
-    makeTest(rule, scripts.standardConfig.valid, true, standardConfig);
-  });
+ruleTester.addTestGroup('standard-fail', 'should fail with standard config', [
+  {
+    code: `function(err, stream) { stream.on('done', function(){exit(0)} }`,
+    errors: [error]
+  },
+  {
+    code: `function loadData (err, data) { doSomething(); }`,
+    errors: [error]
+  },
+  {
+    code: dedent`
+      test(function (err) {
+        console.log('hello world')
+      })`,
+    errors: [error]
+  },
+  { code: `test(err => undefined)`, errors: [error] },
+  { code: `const cb = (err) => null`, errors: [error] },
+  { code: `var cb = function (err) {}`, errors: [error] },
+  { code: dedent`
+    function loadData (err, data) {
+      if (error) {
+          console.log(error.stack);
+      }
+      doSomething();
+    }`,
+    errors: [error]
+  }
+]);
 
-  it('should fail with standard config', function testVariables() {
-    makeTest(rule, scripts.standardConfig.invalid, false, standardConfig);
-  });
+ruleTester.addTestGroup('custom-error-name-pass', 'should pass with custom error name', [
+  { code: `function(errorMsg, stream) { console.error(errorMsg) }`, options: ['errorMsg'] },
+  { code: `function(err, stream) { }`, options: ['errorMsg'] }
+]);
 
-  it('should pass with custom error name', function testVariables() {
-    makeTest(rule, scripts.customErrorNameConfig.valid, true, customErrorNameConfig);
-  });
+ruleTester.addTestGroup('custom-error-name-fail', 'should fail with custom error name', [
+  { code: `function(errorMsg, stream) { }`, options: ['errorMsg'], errors: [error] }
+]);
 
-  it('should fail with custom error name', function testVariables() {
-    makeTest(rule, scripts.customErrorNameConfig.invalid, false, customErrorNameConfig);
-  });
+ruleTester.addTestGroup('custom-error-regex-pass', 'should pass with custom error regex', [
+  {
+    code: `function(errorMsg, stream) { console.error(errorMsg) }`,
+    options: ['^(err|error|errorMsg)$']
+  }
+]);
 
-  it('should pass with custom error regex', function testVariables() {
-    makeTest(rule, scripts.customErrorRegexConfig.valid, true, customErrorRegexConfig);
-  });
+ruleTester.addTestGroup('custom-error-regex-fail', 'should fail with custom error regex', [
+  {
+    code: `function(err, stream) { }`,
+    options: ['^(err|error|errorMsg)$'],
+    errors: [error]
+  },
+  {
+    code: `function(error, stream) { }`,
+    options: ['^(err|error|errorMsg)$'],
+    errors: [error]
+  },
+  {
+    code: `function(errorMsg, stream) { }`,
+    options: ['^(err|error|errorMsg)$'],
+    errors: [error]
+  }
+]);
 
-  it('should fail with custom error regex', function testVariables() {
-    makeTest(rule, scripts.customErrorRegexConfig.invalid, false, customErrorRegexConfig);
-  });
-});
+ruleTester.runTests();

--- a/src/test/rules/handleCallbackErrRuleTests.ts
+++ b/src/test/rules/handleCallbackErrRuleTests.ts
@@ -31,6 +31,22 @@ ruleTester.addTestGroup('standard-pass', 'should pass with standard config', [
         cb(err)
       })
     }`,
+  dedent`
+    app.listen(PORT, err => {
+      if (err) {
+        console.log(err);
+        return;
+      }
+    }
+    `,
+  dedent`
+    app.listen(PORT, (err) => {
+      if (err) {
+        console.log(err);
+        return;
+      }
+    }
+    `,
   `function handle (arg, err) {}`
 ]);
 
@@ -94,6 +110,180 @@ ruleTester.addTestGroup('custom-error-regex-fail', 'should fail with custom erro
   {
     code: `function(errorMsg, stream) { }`,
     options: ['^(err|error|errorMsg)$'],
+    errors: [error]
+  }
+]);
+
+ruleTester.addTestGroup('eslint-valid', 'should pass eslint valid tests', [
+  'function test(error) {}',
+  'function test(err) {console.log(err);}',
+  "function test(err, data) {if(err){ data = 'ERROR';}}",
+  'var test = function(err) {console.log(err);};',
+  'var test = function(err) {if(err){/* do nothing */}};',
+  'var test = function(err) {if(!err){doSomethingHere();}else{};}',
+  'var test = function(err, data) {if(!err) { good(); } else { bad(); }}',
+  'try { } catch(err) {}',
+  {
+    code: dedent`
+      function test(err) {
+        try {
+          console.log('error', err);
+          throw Error('some error');
+        } catch (err) {
+          console.log('Did you handle the original error?', err);
+        }
+      }`
+  },
+  dedent`
+    getData(function(err, data) {
+      if (err) {}
+      getMoreDataWith(data, function(err, moreData) {
+        if (err) {}
+        getEvenMoreDataWith(moreData, function(err, allOfTheThings) {
+          if (err) {}
+        });
+      });
+    });`,
+  'var test = function(err) {if(! err){doSomethingHere();}};',
+  dedent`
+    function test(err, data) {
+      if (data) {
+        doSomething(function(err) {
+          console.error(err);
+        });
+      } else if (err) {
+        console.log(err);
+      }
+    }`,
+  dedent`
+    function handler(err, data) {
+      if (data) {
+        doSomethingWith(data);
+      } else if (err) {
+        console.log(err);
+      }
+    }`,
+  'function handler(err) {logThisAction(function(err) {if (err) {}}); console.log(err);}',
+  'function userHandler(err) {process.nextTick(function() {if (err) {}})}',
+  dedent`
+    function help() {
+      function userHandler(err) {
+        function tester() {
+          err;
+          process.nextTick(function() {
+            err;
+          });
+        }
+      }
+    }`,
+  "function help(done) { var err = new Error('error'); done(); }",
+  { code: 'var test = err => err;' },
+  { code: 'var test = err => !err;' },
+  { code: 'var test = err => err.message;' },
+  { code: 'var test = function(error) {if(error){/* do nothing */}};', options: ['error'] },
+  { code: 'var test = (error) => {if(error){/* do nothing */}};', options: ['error'] },
+  { code: 'var test = function(error) {if(! error){doSomethingHere();}};', options: ['error'] },
+  { code: 'var test = function(err) { console.log(err); };', options: ['^(err|error)$'] },
+  { code: 'var test = function(error) { console.log(error); };', options: ['^(err|error)$'] },
+  { code: 'var test = function(anyError) { console.log(anyError); };', options: ['^.+Error$'] },
+  { code: 'var test = function(any_error) { console.log(anyError); };', options: ['^.+Error$'] },
+  {
+    code: 'var test = function(any_error) { console.log(any_error); };',
+    options: ['^.+(e|E)rror$']
+  }
+]);
+
+ruleTester.addTestGroup('eslint-invalid', 'should fail eslint invalid tests', [
+  { code: 'function test(err) {}', errors: [error] },
+  { code: 'function test(err, data) {}', errors: [error] },
+  { code: 'function test(err) {errorLookingWord();}', errors: [error] },
+  { code: 'function test(err) {try{} catch(err) {}}', errors: [error] },
+  {
+    code: dedent`
+      function test(err) {
+        try{}
+        catch(err) {
+          console.log('did not handle the test err', err);
+        }
+      }`,
+    errors: [error]
+  },
+  { code: dedent`
+      function test(err, callback) {
+        foo(function(err, callback) {
+        });
+      }`,
+    errors: [error, error]
+  },
+  { code: 'var test = (err) => {};', errors: [error] },
+  { code: 'var test = function(err) {};', errors: [error] },
+  { code: 'var test = function test(err, data) {};', errors: [error] },
+  { code: 'var test = function test(err) {/* if(err){} */};', errors: [error] },
+  { code: dedent`
+      function test(err) {
+        doSomethingHere(function(err){
+          console.log(err);
+        })
+      }`,
+    errors: [error]
+  },
+  { code: 'function test(error) {}', options: ['error'], errors: [error] },
+  {
+    code: dedent`
+      getData(function(err, data) {
+        getMoreDataWith(data, function(err, moreData) {
+          if (err) {}
+          getEvenMoreDataWith(moreData, function(err, allOfTheThings) {
+            if (err) {}
+          });
+        }); 
+      });`,
+    errors: [error]
+  },
+  { code: dedent`
+    getData(function(err, data) {
+      getMoreDataWith(data, function(err, moreData) {
+        getEvenMoreDataWith(moreData, function(err, allOfTheThings) {
+          if (err) {}
+        });
+      });
+    });`,
+    errors: [error, error]
+  },
+  { code: dedent`
+    function userHandler(err) {
+      logThisAction(function(err) {
+        if (err) {
+          console.log(err);
+        }
+      })
+    }`,
+    errors: [error]},
+  { code: dedent`
+    function help() {
+      function userHandler(err) {
+        function tester(err) {
+          err;
+          process.nextTick(function() {
+            err;
+          });
+        }
+      }
+    }`,
+    errors: [error]
+  },
+  {
+    code: 'var test = function(anyError) { console.log(otherError); };',
+    options: ['^.+Error$'],
+    errors: [error]
+  },
+  {
+    code: 'var test = function(anyError) { };',
+    options: ['^.+Error$'],
+    errors: [error]},
+  {
+    code: 'var test = function(err) { console.log(error); };',
+    options: ['^(err|error)$'],
     errors: [error]
   }
 ]);


### PR DESCRIPTION
The current code for the rule as it stands has a bug. The line

```ts
const highlights = this.languageService.getDocumentHighlights(fileName, parameter.pos, [fileName]);
```

should be

```ts
const highlights = this.languageService.getDocumentHighlights(fileName, parameter.name.getStart(), [fileName]);
```

Making that change fixes issue #146. In this PR however, I have removed the usage of the languageService. Each call to`getDocumentHighlights` triggers a function which will search for the parameter in the document tree. The change I made is based on the `prefer-arrow-function` rule which keeps track of each function scope to determine if we make use of the error parameter. Based on some simple comparisons as noted on the issue we do get some performance with this change.