### PR TITLE
[docs] moving rule/test source links to the header

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,12 +17,14 @@ When opening a new [issue] please try to include the following information as th
 the issue easier and quicker.
 
  * tslint and typescript version.
-   ```
-   $ tslint --version
-   4.0.0
-   $ tsc --version
-   Version 2.0.10
-   ```
+
+       ```sh
+$ tslint --version
+4.0.0
+$ tsc --version
+Version 2.0.10
+       ```
+
  * `tslint.json` configuration.
  * typescript code being linted.
  * actual behavior.

--- a/src/docs/rules/arrayBracketSpacingRule.md
+++ b/src/docs/rules/arrayBracketSpacingRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## array-bracket-spacing (ESLint: [array-bracket-spacing](http://eslint.org/docs/rules/array-bracket-spacing))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/arrayBracketSpacingRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/arrayBracketSpacingRuleTests.ts)
 
 enforce spacing inside array brackets
 
@@ -28,7 +30,5 @@ enforce spacing inside array brackets
     }
   ]
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/arrayBracketSpacingRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/arrayBracketSpacingRuleTests.ts)**
 
 <!-- End:AutoDoc -->

--- a/src/docs/rules/blockSpacingRule.md
+++ b/src/docs/rules/blockSpacingRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## block-spacing (ESLint: [block-spacing](http://eslint.org/docs/rules/block-spacing))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/blockSpacingRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/blockSpacingRuleTests.ts)
 
 disallow or enforce spaces inside of single line blocks
 
@@ -18,7 +20,5 @@ disallow or enforce spaces inside of single line blocks
     "never"
   ]
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/blockSpacingRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/blockSpacingRuleTests.ts)**
 
 <!-- End:AutoDoc -->

--- a/src/docs/rules/braceStyleRule.md
+++ b/src/docs/rules/braceStyleRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## brace-style (ESLint: [brace-style](http://eslint.org/docs/rules/brace-style))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/braceStyleRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/braceStyleRuleTests.ts)
 
 enforce one true brace style
 
@@ -34,7 +36,5 @@ enforce one true brace style
     }
   ]
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/braceStyleRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/braceStyleRuleTests.ts)**
 
 <!-- End:AutoDoc -->

--- a/src/docs/rules/handleCallbackErrRule.md
+++ b/src/docs/rules/handleCallbackErrRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## handle-callback-err (ESLint: [handle-callback-err](http://eslint.org/docs/rules/handle-callback-err))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/handleCallbackErrRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/handleCallbackErrRuleTests.ts)
 
 enforce error handling in callbacks
 
@@ -53,6 +55,4 @@ regexp pattern.
   "maxLength": 1
 }
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/handleCallbackErrRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/handleCallbackErrRuleTests.ts)**
 <!-- End:AutoDoc -->

--- a/src/docs/rules/noConstantConditionRule.md
+++ b/src/docs/rules/noConstantConditionRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## no-constant-condition (ESLint: [no-constant-condition](http://eslint.org/docs/rules/no-constant-condition))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noConstantConditionRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noConstantConditionRuleTests.ts)
 
 disallow use of constant expressions in conditions (recommended)
 
@@ -8,7 +10,5 @@ disallow use of constant expressions in conditions (recommended)
 ```json
 "no-constant-condition": true
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noConstantConditionRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noConstantConditionRuleTests.ts)**
 
 <!-- End:AutoDoc -->

--- a/src/docs/rules/noControlRegexRule.md
+++ b/src/docs/rules/noControlRegexRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## no-control-regex (ESLint: [no-control-regex](http://eslint.org/docs/rules/no-control-regex))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noControlRegexRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noControlRegexRuleTests.ts)
 
 disallow control characters in regular expressions (recommended)
 
@@ -8,7 +10,5 @@ disallow control characters in regular expressions (recommended)
 ```json
 "no-control-regex": true
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noControlRegexRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noControlRegexRuleTests.ts)**
 
 <!-- End:AutoDoc -->

--- a/src/docs/rules/noDuplicateCaseRule.md
+++ b/src/docs/rules/noDuplicateCaseRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## no-duplicate-case (ESLint: [no-duplicate-case](http://eslint.org/docs/rules/no-duplicate-case))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noDuplicateCaseRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noDuplicateCaseRuleTests.ts)
 
 disallow a duplicate case label. (recommended)
 
@@ -8,7 +10,5 @@ disallow a duplicate case label. (recommended)
 ```json
 "no-duplicate-case": true
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noDuplicateCaseRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noDuplicateCaseRuleTests.ts)**
 
 <!-- End:AutoDoc -->

--- a/src/docs/rules/noEmptyCharacterClassRule.md
+++ b/src/docs/rules/noEmptyCharacterClassRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## no-empty-character-class (ESLint: [no-empty-character-class](http://eslint.org/docs/rules/no-empty-character-class))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noEmptyCharacterClassRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noEmptyCharacterClassRuleTests.ts)
 
 disallow the use of empty character classes in regular expressions (recommended)
 
@@ -8,7 +10,5 @@ disallow the use of empty character classes in regular expressions (recommended)
 ```json
 "no-empty-character-class": true
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noEmptyCharacterClassRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noEmptyCharacterClassRuleTests.ts)**
 
 <!-- End:AutoDoc -->

--- a/src/docs/rules/noExAssignRule.md
+++ b/src/docs/rules/noExAssignRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## no-ex-assign (ESLint: [no-ex-assign](http://eslint.org/docs/rules/no-ex-assign))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noExAssignRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noExAssignRuleTests.ts)
 
 disallow assigning to the exception in a `catch` block (recommended)
 
@@ -8,7 +10,5 @@ disallow assigning to the exception in a `catch` block (recommended)
 ```json
 "no-ex-assign": true
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noExAssignRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noExAssignRuleTests.ts)**
 
 <!-- End:AutoDoc -->

--- a/src/docs/rules/noExtraBooleanCastRule.md
+++ b/src/docs/rules/noExtraBooleanCastRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## no-extra-boolean-cast (ESLint: [no-extra-boolean-cast](http://eslint.org/docs/rules/no-extra-boolean-cast))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noExtraBooleanCastRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noExtraBooleanCastRuleTests.ts)
 
 disallow double-negation boolean casts in a boolean context (recommended)
 
@@ -8,7 +10,5 @@ disallow double-negation boolean casts in a boolean context (recommended)
 ```json
 "no-extra-boolean-cast": true
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noExtraBooleanCastRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noExtraBooleanCastRuleTests.ts)**
 
 <!-- End:AutoDoc -->

--- a/src/docs/rules/noExtraSemiRule.md
+++ b/src/docs/rules/noExtraSemiRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## no-extra-semi (ESLint: [no-extra-semi](http://eslint.org/docs/rules/no-extra-semi))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noExtraSemiRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noExtraSemiRuleTests.ts)
 
 disallow unnecessary semicolons (recommended)
 
@@ -8,7 +10,5 @@ disallow unnecessary semicolons (recommended)
 ```json
 "no-extra-semi": true
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noExtraSemiRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noExtraSemiRuleTests.ts)**
 
 <!-- End:AutoDoc -->

--- a/src/docs/rules/noInnerDeclarationsRule.md
+++ b/src/docs/rules/noInnerDeclarationsRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## no-inner-declarations (ESLint: [no-inner-declarations](http://eslint.org/docs/rules/no-inner-declarations))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noInnerDeclarationsRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noInnerDeclarationsRuleTests.ts)
 
 disallow function or variable declarations in nested blocks (recommended)
 
@@ -18,7 +20,5 @@ disallow function or variable declarations in nested blocks (recommended)
   "both"
 ]
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noInnerDeclarationsRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noInnerDeclarationsRuleTests.ts)**
 
 <!-- End:AutoDoc -->

--- a/src/docs/rules/noInvalidRegexpRule.md
+++ b/src/docs/rules/noInvalidRegexpRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## no-invalid-regexp (ESLint: [no-invalid-regexp](http://eslint.org/docs/rules/no-invalid-regexp))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noInvalidRegexpRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noInvalidRegexpRuleTests.ts)
 
 disallow invalid regular expression strings in the `RegExp` constructor (recommended)
 
@@ -8,7 +10,5 @@ disallow invalid regular expression strings in the `RegExp` constructor (recomme
 ```json
 "no-invalid-regexp": true
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noInvalidRegexpRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noInvalidRegexpRuleTests.ts)**
 
 <!-- End:AutoDoc -->

--- a/src/docs/rules/noIrregularWhitespaceRule.md
+++ b/src/docs/rules/noIrregularWhitespaceRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## no-irregular-whitespace (ESLint: [no-irregular-whitespace](http://eslint.org/docs/rules/no-irregular-whitespace))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noIrregularWhitespaceRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noIrregularWhitespaceRuleTests.ts)
 
 disallow irregular whitespace outside of strings and comments (recommended)
 
@@ -8,7 +10,5 @@ disallow irregular whitespace outside of strings and comments (recommended)
 ```json
 "no-irregular-whitespace": true
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noIrregularWhitespaceRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noIrregularWhitespaceRuleTests.ts)**
 
 <!-- End:AutoDoc -->

--- a/src/docs/rules/noMultiSpacesRule.md
+++ b/src/docs/rules/noMultiSpacesRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## no-multi-spaces (ESLint: [no-multi-spaces](http://eslint.org/docs/rules/no-multi-spaces))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noMultiSpacesRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noMultiSpacesRuleTests.ts)
 
 disallow use of multiple spaces
 
@@ -13,8 +15,6 @@ disallow use of multiple spaces
     }
   ]
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noMultiSpacesRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noMultiSpacesRuleTests.ts)**
 
 <!-- End:AutoDoc -->
 

--- a/src/docs/rules/noRegexSpacesRule.md
+++ b/src/docs/rules/noRegexSpacesRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## no-regex-spaces (ESLint: [no-regex-spaces](http://eslint.org/docs/rules/no-regex-spaces))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noRegexSpacesRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noRegexSpacesRuleTests.ts)
 
 disallow multiple spaces in a regular expression literal (recommended)
 
@@ -8,7 +10,5 @@ disallow multiple spaces in a regular expression literal (recommended)
 ```json
 "no-regex-spaces": true
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noRegexSpacesRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noRegexSpacesRuleTests.ts)**
 
 <!-- End:AutoDoc -->

--- a/src/docs/rules/noSparseArraysRule.md
+++ b/src/docs/rules/noSparseArraysRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## no-sparse-arrays (ESLint: [no-sparse-arrays](http://eslint.org/docs/rules/no-sparse-arrays))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noSparseArraysRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noSparseArraysRuleTests.ts)
 
 disallow sparse arrays (recommended)
 
@@ -8,7 +10,5 @@ disallow sparse arrays (recommended)
 ```json
 "no-sparse-arrays": true
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noSparseArraysRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noSparseArraysRuleTests.ts)**
 
 <!-- End:AutoDoc -->

--- a/src/docs/rules/noUnexpectedMultilineRule.md
+++ b/src/docs/rules/noUnexpectedMultilineRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## no-unexpected-multiline (ESLint: [no-unexpected-multiline](http://eslint.org/docs/rules/no-unexpected-multiline))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noUnexpectedMultilineRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noUnexpectedMultilineRuleTests.ts)
 
 Avoid code that looks like two expressions but is actually one
 
@@ -8,7 +10,5 @@ Avoid code that looks like two expressions but is actually one
 ```json
 "no-unexpected-multiline": true
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/noUnexpectedMultilineRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/noUnexpectedMultilineRuleTests.ts)**
 
 <!-- End:AutoDoc -->

--- a/src/docs/rules/objectCurlySpacingRule.md
+++ b/src/docs/rules/objectCurlySpacingRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## object-curly-spacing (ESLint: [object-curly-spacing](http://eslint.org/docs/rules/object-curly-spacing))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/objectCurlySpacingRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/objectCurlySpacingRuleTests.ts)
 
 require or disallow padding inside curly braces
 
@@ -18,7 +20,5 @@ require or disallow padding inside curly braces
     "never"
   ]
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/objectCurlySpacingRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/objectCurlySpacingRuleTests.ts)**
 
 <!-- End:AutoDoc -->

--- a/src/docs/rules/terArrowBodyStyleRule.md
+++ b/src/docs/rules/terArrowBodyStyleRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## ter-arrow-body-style (ESLint: [arrow-body-style](http://eslint.org/docs/rules/arrow-body-style))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/terArrowBodyStyleRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/terArrowBodyStyleRuleTests.ts)
 
 require braces in arrow function body
 
@@ -80,6 +82,4 @@ return for object literals.
   ]
 }
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/terArrowBodyStyleRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/terArrowBodyStyleRuleTests.ts)**
 <!-- End:AutoDoc -->

--- a/src/docs/rules/terArrowParensRule.md
+++ b/src/docs/rules/terArrowParensRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## ter-arrow-parens (ESLint: [arrow-parens](http://eslint.org/docs/rules/arrow-parens))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/terArrowParensRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/terArrowParensRuleTests.ts)
 
 require parens in arrow function arguments
 
@@ -65,8 +67,6 @@ Object properties for variants of the `"as-needed"` option:
   "maxLength": 1
 }
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/terArrowParensRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/terArrowParensRuleTests.ts)**
 <!-- End:AutoDoc -->
 
 #### TSLint Rule: [`arrow-parens`]

--- a/src/docs/rules/terArrowSpacingRule.md
+++ b/src/docs/rules/terArrowSpacingRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## ter-arrow-spacing (ESLint: [arrow-spacing](http://eslint.org/docs/rules/arrow-spacing))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/terArrowSpacingRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/terArrowSpacingRuleTests.ts)
 
 require space before/after arrow function's arrow
 
@@ -50,6 +52,4 @@ The default configuration is `{ "before": true, "after": true }`.
   "maxLength": 1
 }
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/terArrowSpacingRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/terArrowSpacingRuleTests.ts)**
 <!-- End:AutoDoc -->

--- a/src/docs/rules/terIndentRule.md
+++ b/src/docs/rules/terIndentRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## ter-indent (ESLint: [indent](http://eslint.org/docs/rules/indent))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/terIndentRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/terIndentRuleTests.ts)
 
 enforce consistent indentation
 
@@ -151,8 +153,6 @@ An object may be provided to fine tune the indentation rules:
   "maxLength": 2
 }
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/terIndentRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/terIndentRuleTests.ts)**
 <!-- End:AutoDoc -->
 
 ### TSLint Rule: `indent`

--- a/src/docs/rules/terMaxLenRule.md
+++ b/src/docs/rules/terMaxLenRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## ter-max-len (ESLint: [max-len](http://eslint.org/docs/rules/max-len))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/terMaxLenRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/terMaxLenRuleTests.ts)
 
 enforce a maximum line length
 
@@ -116,6 +118,4 @@ An optional object may be provided to fine tune the rule:
   "maxLength": 3
 }
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/terMaxLenRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/terMaxLenRuleTests.ts)**
 <!-- End:AutoDoc -->

--- a/src/docs/rules/terPreferArrowCallbackRule.md
+++ b/src/docs/rules/terPreferArrowCallbackRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## ter-prefer-arrow-callback (ESLint: [prefer-arrow-callback](http://eslint.org/docs/rules/prefer-arrow-callback))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/terPreferArrowCallbackRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/terPreferArrowCallbackRuleTests.ts)
 
 suggest using arrow functions as callbacks
 
@@ -70,8 +72,6 @@ may specify the following properties:
   "maxLength": 1
 }
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/terPreferArrowCallbackRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/terPreferArrowCallbackRuleTests.ts)**
 <!-- End:AutoDoc -->
 
 #### TSLint Rule: [`only-arrow-functions`]

--- a/src/docs/rules/useIsnanRule.md
+++ b/src/docs/rules/useIsnanRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## use-isnan (ESLint: [use-isnan](http://eslint.org/docs/rules/use-isnan))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/useIsnanRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/useIsnanRuleTests.ts)
 
 disallow comparisons with the value `NaN` (recommended)
 
@@ -8,7 +10,5 @@ disallow comparisons with the value `NaN` (recommended)
 ```json
 "use-isnan": true
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/useIsnanRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/useIsnanRuleTests.ts)**
 
 <!-- End:AutoDoc -->

--- a/src/docs/rules/validJsdocRule.md
+++ b/src/docs/rules/validJsdocRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## valid-jsdoc (ESLint: [valid-jsdoc](http://eslint.org/docs/rules/valid-jsdoc))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/validJsdocRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/validJsdocRuleTests.ts)
 
 Ensure JSDoc comments are valid
 
@@ -19,7 +21,5 @@ Ensure JSDoc comments are valid
   }
 ]
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/validJsdocRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/validJsdocRuleTests.ts)**
 
 <!-- End:AutoDoc -->

--- a/src/docs/rules/validTypeofRule.md
+++ b/src/docs/rules/validTypeofRule.md
@@ -1,5 +1,7 @@
 <!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
 ## valid-typeof (ESLint: [valid-typeof](http://eslint.org/docs/rules/valid-typeof))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/validTypeofRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/validTypeofRuleTests.ts)
 
 Ensure that the results of typeof are compared against a valid string (recommended)
 
@@ -8,7 +10,5 @@ Ensure that the results of typeof are compared against a valid string (recommend
 ```json
 "valid-typeof": true
 ```
-**[:straight_ruler: Rule source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/validTypeofRule.ts)**
-**[:blue_book: Test source](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/validTypeofRuleTests.ts)**
 
 <!-- End:AutoDoc -->

--- a/src/readme/index.ts
+++ b/src/readme/index.ts
@@ -64,6 +64,8 @@ function createRuleContent(rule: IRule) {
   const module = require(moduleName);
   const metaData = module.Rule.metadata;
   const srcBase = 'https://github.com/buzinas/tslint-eslint-rules/blob/master/src';
+  const ruleBadge = 'https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg';
+  const testBadge = 'https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg';
   if (metaData) {
     // Checking that the rule name and description match
     if (metaData.ruleName !== rule.tslintRule) {
@@ -83,14 +85,15 @@ function createRuleContent(rule: IRule) {
       '```'
     ].join('\n');
     return [
-      `## ${rule.tslintRule} (ESLint: [${rule.eslintRule}](${rule.eslintUrl}))\n`,
+      `## ${rule.tslintRule} (ESLint: [${rule.eslintRule}](${rule.eslintUrl}))`,
+      `[![rule_source](${ruleBadge})](${srcBase}/rules/${ruleName}Rule.ts)`,
+      `[![test_source](${testBadge})](${srcBase}/test/rules/${ruleName}RuleTests.ts)`,
+      '',
       `${rule.description}\n`,
       `#### Rationale\n${metaData.rationale}`,
       `### Config\n${metaData.optionsDescription}`,
       `#### Examples\n\n${examples}`,
-      `#### Schema\n\n${schema}`,
-      `**[:straight_ruler: Rule source](${srcBase}/rules/${ruleName}Rule.ts)**`,
-      `**[:blue_book: Test source](${srcBase}/test/rules/${ruleName}RuleTests.ts)**`
+      `#### Schema\n\n${schema}`
     ].join('\n');
   }
 
@@ -98,10 +101,10 @@ function createRuleContent(rule: IRule) {
   const usage = rule.usage ? `\n\n### Usage\n\n${formatUsage(rule.usage)}` : '';
   const note = rule.note ? `\n\n### Note\n\n${rule.note}\n` : '';
   return `## ${rule.tslintRule} (ESLint: [${rule.eslintRule}](${rule.eslintUrl}))
+[![rule_source](${ruleBadge})](${srcBase}/rules/${ruleName}Rule.ts)
+[![test_source](${testBadge})](${srcBase}/test/rules/${ruleName}RuleTests.ts)
 
 ${rule.description}${usage}${note}
-**[:straight_ruler: Rule source](${srcBase}/rules/${ruleName}Rule.ts)**
-**[:blue_book: Test source](${srcBase}/test/rules/${ruleName}RuleTests.ts)**
 `;
 }
 


### PR DESCRIPTION
Using a badge for them look nicer. I was intending on making a footer for the page but this probably won't look so good with the current documentation we have. I might do it in the future.