### PR TITLE
[bug] fixed ter-indent rule for variable declarations with jsdoc

### DIFF
--- a/src/rules/terIndentRule.ts
+++ b/src/rules/terIndentRule.ts
@@ -1013,6 +1013,9 @@ class IndentWalker extends Lint.RuleWalker {
       return;
     }
     const len = list.getChildCount();
+    if (len === 0) {
+      return;
+    }
     const lastElement = list.getChildAt(len - 1);
     const lastToken = node.getLastToken();
     const lastTokenLine = this.getLine(lastToken, true);

--- a/src/test/rules/terIndentRuleTests.ts
+++ b/src/test/rules/terIndentRuleTests.ts
@@ -135,6 +135,31 @@ ruleTester.addTestGroup('no-options', 'should capture the correct indentation wi
 ruleTester.addTestGroup('indent-number', 'should force a certain indentation number', [
   {
     code: dedent`
+      /**
+       * @var {string}
+       */
+      const FOO = 'bar';`,
+    options: [4]
+  },
+  {
+    code: dedent`
+      /**
+       * @var {string}
+       */
+       const FOO = 'bar';`,
+    options: [4],
+    errors: expecting([[4, 0, 1]])
+  },
+  {
+    code: dedent`
+      /**
+       * @param {string} text
+       */
+      const log = (text) => console.log(text);`,
+    options: [4]
+  },
+  {
+    code: dedent`
       var x = [
           'a',
           'b',
@@ -1541,6 +1566,27 @@ ruleTester.addTestGroup('variable-declarator', 'should handle variable declarato
     code: '\nlet geometry,\n  rotate;',
     options: [2, { VariableDeclarator: 2 }],
     errors: expecting([[2, 4, 2]])
+  },
+  {
+    code: dedent`
+      /**
+       * @var {number}
+       * @var {number}
+       */
+      var geometry,
+          rotate;`,
+    options: [4, { VariableDeclarator: 1 }]
+  },
+  {
+    code: dedent`
+      /**
+       * @var {number}
+       * @var {number}
+       */
+      var geometry,
+         rotate;`,
+    options: [4, { VariableDeclarator: 1 }],
+    errors: expecting([[6, 4, 3]])
   },
   {
     code: dedent`


### PR DESCRIPTION
It appears that jsdoc blocks before variable declarations break the `ter-indent` rule when using TypeScript 2.1.

Output:

```  1) ter-indent should force a certain indentation number:
     TypeError: Cannot read property 'getEnd' of undefined
      at IndentWalker.getLineAndCharacter (dist/rules/terIndentRule.js:215:41)
      at IndentWalker.getLine (dist/rules/terIndentRule.js:220:21)
      at IndentWalker.visitVariableStatement (dist/rules/terIndentRule.js:753:36)
      at IndentWalker.SyntaxWalker.visitNode (node_modules/tslint/lib/language/walker/syntaxWalker.js:502:22)
      at node_modules/tslint/lib/language/walker/syntaxWalker.js:517:63
      at visitEachNode (node_modules/typescript/lib/typescript.js:13907:30)
      at Object.forEachChild (node_modules/typescript/lib/typescript.js:14078:24)
      at IndentWalker.SyntaxWalker.walkChildren (node_modules/tslint/lib/language/walker/syntaxWalker.js:517:12)
      at IndentWalker.SyntaxWalker.visitSourceFile (node_modules/tslint/lib/language/walker/syntaxWalker.js:218:14)
      at IndentWalker.visitSourceFile (dist/rules/terIndentRule.js:869:42)
      at IndentWalker.SyntaxWalker.visitNode (node_modules/tslint/lib/language/walker/syntaxWalker.js:463:22)
      at IndentWalker.SyntaxWalker.walk (node_modules/tslint/lib/language/walker/syntaxWalker.js:23:14)
      at Rule.AbstractRule.applyWithWalker (node_modules/tslint/lib/language/rule/abstractRule.js:44:16)
      at Rule.apply (dist/rules/terIndentRule.js:45:21)
      at Linter.applyRule (node_modules/tslint/lib/linter.js:143:33)
      at Linter.lint (node_modules/tslint/lib/linter.js:109:41)
      at Test.runTest (dist/test/rules/ruleTester.js:63:16)
      at dist/test/rules/ruleTester.js:172:38
      at Array.forEach (native)
      at Context.<anonymous> (dist/test/rules/ruleTester.js:170:37)```

tslint: 4.0.2
tslint-eslint-rules: 3.2.0
typescript: 2.1.4
node: 6.6.0