### PR TITLE
[feat] exported a configuration from this package (closes #165)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,20 +23,22 @@ Now you can combine both worlds by using this TSLint plugin!
 npm install --save-dev tslint-eslint-rules
 ```
 
-### Configure TSLint to use `tslint-eslint-rules` folder:
+### Configure TSLint to use `tslint-eslint-rules`:
 
-In your `tslint.json` file, add the `rulesDirectory` property, e.g:
+In your `tslint.json` file, extend this package, e.g:
 
-  ```json
-  {
-    "rulesDirectory": "node_modules/tslint-eslint-rules/dist/rules",
-    "rules": {
-      "no-constant-condition": true
-    }
+```json
+{
+  "extends": [
+    "tslint-eslint-rules"
+  ],
+  "rules": {
+    "no-constant-condition": true
   }
-  ```
+}
+```
 
-  You can also pass an array of strings to the `rulesDirectory` property to combine this plugin with other community custom rules.
+You can also extend other tslint config packages to combine this plugin with other community custom rules.
 
 
 ### Configure your rules

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+// unopinionated extensable tslint configuration
+// loads rules for extending packages, but does not enable any
 module.exports = {
     rulesDirectory: "dist/rules",
 };

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+    rulesDirectory: "dist/rules",
+};

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "typescript": "^2.0.3",
     "yargs": "^5.0.0"
   },
+  "peerDependencies": {
+    "tslint": "^4.0.0"
+  },
   "dependencies": {
     "doctrine": "^0.7.2",
     "tslint": "^4.0.0"


### PR DESCRIPTION
Supports extending configurations that use these rules. See #165 for more information.

This doesn't enforce any defaults for rules, although that's possible.