### PR TITLE
[feat] Add auto fix feature to object-curly-spacing rule

### DIFF
--- a/src/rules/objectCurlySpacingRule.ts
+++ b/src/rules/objectCurlySpacingRule.ts
@@ -45,7 +45,7 @@ class ObjectCurlySpacingWalker extends Lint.RuleWalker {
 
   private checkSpacingInsideBraces(node: ts.Node): void {
     const text = node.getText();
-    if (text.indexOf('\n') !== -1 || text === '{}') {
+    if (text.indexOf('\n') !== -1 || /^\{\s*\}$/.test(text)) {
       // Rule does not apply when the braces span multiple lines
       return;
     }
@@ -53,19 +53,22 @@ class ObjectCurlySpacingWalker extends Lint.RuleWalker {
     const trailingSpace = text.match(/(\s{0,2})}$/)[1].length;
     if (this.always) {
       if (leadingSpace === 0) {
-        this.addFailure(this.createFailure(node.getStart(), 1, Rule.FAILURE_STRING.always.start));
+        const fix = this.createFix(this.appendText(node.getStart() + 1, ' '));
+        this.addFailure(this.createFailure(node.getStart(), 1, Rule.FAILURE_STRING.always.start, fix));
       }
       if (trailingSpace === 0) {
-        this.addFailure(this.createFailure(node.getEnd() - 1, 1, Rule.FAILURE_STRING.always.end));
+        const fix = this.createFix(this.appendText(node.getEnd() - 1, ' '));
+        this.addFailure(this.createFailure(node.getEnd() - 1, 1, Rule.FAILURE_STRING.always.end, fix));
       }
     } else {
       if (leadingSpace > 0) {
-        this.addFailure(this.createFailure(node.getStart(), 1, Rule.FAILURE_STRING.never.start));
+        const fix = this.createFix(this.deleteText(node.getStart() + 1, leadingSpace));
+        this.addFailure(this.createFailure(node.getStart(), 1, Rule.FAILURE_STRING.never.start, fix));
       }
       if (trailingSpace > 0) {
-        this.addFailure(this.createFailure(node.getEnd() - 1, 1, Rule.FAILURE_STRING.never.end));
+        const fix = this.createFix(this.deleteText(node.getEnd() - trailingSpace - 1, trailingSpace));
+        this.addFailure(this.createFailure(node.getEnd() - 1, 1, Rule.FAILURE_STRING.never.end, fix));
       }
     }
   }
-
 }

--- a/src/test/rules/helper.ts
+++ b/src/test/rules/helper.ts
@@ -2,20 +2,28 @@
 import { expect } from 'chai';
 import * as Lint from 'tslint';
 
-export function testScript(rule: string, scriptText: string, config: Object): boolean {
-  const options: Lint.ILinterOptions = {
-    fix: false,
-    formatter: 'json',
-    formattersDirectory: 'dist/formatters/',
-    rulesDirectory: 'dist/rules/'
-  };
+const options: Lint.ILinterOptions = {
+  fix: false,
+  formatter: 'json',
+  formattersDirectory: 'dist/formatters/',
+  rulesDirectory: 'dist/rules/'
+};
 
+export function testScript(rule: string, scriptText: string, config: Object): boolean {
   const linter = new Lint.Linter(options);
   linter.lint(`${rule}.ts`, scriptText, config);
 
   const failures = JSON.parse(linter.getResult().output);
 
   return failures.length === 0;
+}
+
+export function fix(rule: string, scriptText: string, config: Object): string {
+  const linter = new Lint.Linter(options);
+  linter.lint(`${rule}.ts`, scriptText, config);
+
+  const fixes = linter.getResult().failures.filter(f => f.hasFix()).map(f => f.getFix());
+  return Lint.Fix.applyAll(scriptText, fixes);
 }
 
 export function makeTest(rule: string, scripts: Array<string>, expected: boolean, config?: { rules: {} }) {
@@ -30,5 +38,20 @@ export function makeTest(rule: string, scripts: Array<string>, expected: boolean
   scripts.forEach((code) => {
     const res = testScript(rule, code, config);
     expect(res).to.equal(expected, code);
+  });
+}
+
+export function makeFixTest(rule: string, inputs: Array<string>, outputs: Array<string>, config?: { rules: {} }) {
+  if (!config) {
+    config = {
+      rules: {}
+    };
+
+    config.rules[rule] = true;
+  }
+
+  inputs.forEach((code, index) => {
+    const res = fix(rule, code, config);
+    expect(res).to.equal(outputs[index], code);
   });
 }

--- a/src/test/rules/objectCurlySpacingRuleTests.ts
+++ b/src/test/rules/objectCurlySpacingRuleTests.ts
@@ -1,5 +1,5 @@
 /// <reference path='../../../typings/mocha/mocha.d.ts' />
-import { makeTest } from './helper';
+import { makeTest, makeFixTest } from './helper';
 
 const rule = 'object-curly-spacing';
 const scripts = {
@@ -50,11 +50,19 @@ describe(rule, function test() {
     makeTest(rule, scripts.always.invalid, false, alwaysConfig);
   });
 
+  it('should add necessary spaces when "always" with fix option', function testVariables() {
+    makeFixTest(rule, scripts.always.invalid, scripts.always.valid, alwaysConfig);
+  });
+
   it('should pass when "never" and there are not spaces inside brackets', function testVariables() {
     makeTest(rule, scripts.never.valid, true, neverConfig);
   });
 
   it('should fail when "never" and there are spaces inside brackets', function testVariables() {
     makeTest(rule, scripts.never.invalid, false, neverConfig);
+  });
+
+  it('should remove unnecessary spaces when "never" with fix option', function testVariables() {
+    makeFixTest(rule, scripts.never.invalid, scripts.never.valid, neverConfig);
   });
 });


### PR DESCRIPTION
With this you can run `tslint` with `--fix` option and all curly braces paddings will be fixed.