### PR TITLE
[chore] dropping support for node 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ language: node_js
 node_js:
   - '6'
   - '4'
-  - '0.10'


### PR DESCRIPTION
TSLint only supports node >=4.1.2.