### PR TITLE
(WIP) Utility to auto-fetch eslint rule config settings

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,7 @@
 .vs
 dist/test
 dist/readme
+!dist/readme/rules.js
 dist/tools
 node_modules
 src

--- a/src/tools/convertEslintConfig.ts
+++ b/src/tools/convertEslintConfig.ts
@@ -1,0 +1,46 @@
+/*
+Utility for using existing eslint rules without duplicating configs.
+
+```js
+import { CLIEngine } from "eslint";
+import { getTslintEslintRulesList } from "tslint-eslint-rules/dist/tools/convertEslintConfig";
+
+const engine = new CLIEngine();
+const config = engine.getConfigForFile("./src");
+
+const rules = getTslintEslintRulesList(config);
+```
+*/
+
+import { IRule, Provider, rules } from '../readme/rules';
+
+function findMetaForEslintRule(eslintRuleName: string): IRule | undefined {
+  const possible = rules.filter(r => r.eslintRule === eslintRuleName);
+  if (possible.length === 1) {
+    return possible[0];
+  }
+  return undefined;
+}
+
+function getRulesList(config: any, provider: Provider) {
+  const rules = config.rules;
+
+  const tslintRules = {};
+  Object.keys(rules).forEach(eslintRuleName => {
+    const meta = findMetaForEslintRule(eslintRuleName);
+
+    if (meta && meta.provider === provider && meta.available && meta.tslintRule && meta.tslintRule !== 'Not applicable') {
+      tslintRules[meta.tslintRule] = rules[eslintRuleName];
+    }
+  });
+
+  return tslintRules;
+}
+
+export function getNativeRulesList(config: any) {
+  return getRulesList(config, 'native');
+}
+
+export function getTslintEslintRulesList(config: any) {
+  return getRulesList(config, 'tslint-eslint-rules');
+}


### PR DESCRIPTION
`tools/convertEslintConfig.ts` methods return drop in configuration options that can be plugged into the `rules` object of your tslint.json. This allows sharing of eslint and tslint configs, which is pretty dang useful.