### PR TITLE
[feat] sort-imports rule that is an ESLint workalike (closes #189)

### DIFF
--- a/src/docs/rules/sortImportsRule.md
+++ b/src/docs/rules/sortImportsRule.md
@@ -20,7 +20,7 @@ This rule checks all import declarations and verifies that all imports are first
   - `all` = import all members provided by exported bindings.
   - `multiple` = import multiple members.
   - `single` = import a single member.
-  - `alias` = creates an alias for a member.
+  - `alias` = creates an alias for a member. This is unique to TER and not in ESLint's `sort-imports`.
 
 #### Examples
 

--- a/src/docs/rules/sortImportsRule.md
+++ b/src/docs/rules/sortImportsRule.md
@@ -6,10 +6,22 @@
 enforce sorting import declarations within module
 
 #### Rationale
-undefined
+
+When declaring multiple imports, a sorted list of import declarations make it easier for developers to read the code and find necessary imports later. This rule is purely a matter of style.
+
+This rule checks all import declarations and verifies that all imports are first sorted by the used member syntax and then alphabetically by the first member or alias name.
+
 ### Config
 
-      
+- `"ignore-case"` does case-insensitive comparisons (default: `false`)
+- `"ignore-member-sort"` allows members in multiple type imports to occur in any order (default: `false`)
+- `"member-syntax-sort-order"` (default: `["none", "all", "multiple", "single", "alias"]`); all 5 items must be present in the array, but you can change the order: 
+  - `none` = import module without exported bindings.
+  - `all` = import all members provided by exported bindings.
+  - `multiple` = import multiple members.
+  - `single` = import a single member.
+  - `alias` = creates an alias for a member.
+
 #### Examples
 
 ```json
@@ -17,15 +29,15 @@ undefined
 ```
 
 ```json
-"sort-imports": [true, { 'ignore-case' }]
+"sort-imports": [true, { "ignore-case" }]
 ```
 
 ```json
-"sort-imports": [true, { 'ignore-member-sort' }]
+"sort-imports": [true, { "ignore-member-sort" }]
 ```
 
 ```json
-"sort-imports": [true, { 'member-syntax-sort-order': ['all', 'single', 'multiple', 'none', 'alias'] }]
+"sort-imports": [true, { "member-syntax-sort-order": ["all", "single", "multiple", "none", "alias"] }]
 ```
 #### Schema
 

--- a/src/docs/rules/sortImportsRule.md
+++ b/src/docs/rules/sortImportsRule.md
@@ -1,0 +1,60 @@
+<!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
+## sort-imports (ESLint: [sort-imports](http://eslint.org/docs/rules/sort-imports))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/sortImportsRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/sortImportsRuleTests.ts)
+
+enforce sorting import declarations within module
+
+#### Rationale
+undefined
+### Config
+
+      
+#### Examples
+
+```json
+"sort-imports": [true]
+```
+
+```json
+"sort-imports": [true, { 'ignore-case' }]
+```
+
+```json
+"sort-imports": [true, { 'ignore-member-sort' }]
+```
+
+```json
+"sort-imports": [true, { 'member-syntax-sort-order': ['all', 'single', 'multiple', 'none', 'alias'] }]
+```
+#### Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "member-syntax-sort-order": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "none",
+          "all",
+          "multiple",
+          "single",
+          "alias"
+        ]
+      },
+      "minLength": 5,
+      "maxLength": 5
+    },
+    "ignore-case": {
+      "type": "boolean"
+    },
+    "ignore-member-sort": {
+      "type": "boolean"
+    }
+  }
+}
+```
+<!-- End:AutoDoc -->

--- a/src/docs/rules/sortImportsRule.md
+++ b/src/docs/rules/sortImportsRule.md
@@ -70,3 +70,6 @@ This rule checks all import declarations and verifies that all imports are first
 }
 ```
 <!-- End:AutoDoc -->
+#### TSLint Rule: [`ordered-imports`]
+
+[`ordered-imports`]: https://palantir.github.io/tslint/rules/ordered-imports/

--- a/src/readme/rules.ts
+++ b/src/readme/rules.ts
@@ -2635,12 +2635,11 @@ const rules: IRule[] = [
   {
     available: true,
     eslintRule: 'sort-imports',
-    tslintRule: 'ordered-imports',
+    tslintRule: 'sort-imports',
     category: 'Stylistic Issues',
     description: 'enforce sorting import declarations within module',
     eslintUrl: 'http://eslint.org/docs/rules/sort-imports',
-    tslintUrl: 'https://palantir.github.io/tslint/rules/ordered-imports',
-    provider: 'native'
+    provider: 'tslint-eslint-rules'
   },
   {
     available: false,

--- a/src/rules/sortImportsRule.ts
+++ b/src/rules/sortImportsRule.ts
@@ -20,7 +20,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         - \`all\` = import all members provided by exported bindings.
         - \`multiple\` = import multiple members.
         - \`single\` = import a single member.
-        - \`alias\` = creates an alias for a member.
+        - \`alias\` = creates an alias for a member. This is unique to TER and not in ESLint's \`sort-imports\`.
       `,
     options: {
       type: 'object',
@@ -89,6 +89,7 @@ class RuleWalker extends Lint.RuleWalker {
     this.ignoreCase = this.hasOption('ignore-case');
     this.ignoreMemberSort = this.hasOption('ignore-member-sort');
     this.expectedOrder = this._processMemberSyntaxSortOrder(optionSet['member-syntax-sort-order']);
+    this.currentSortValue = {sortValue: '', originalValue: ''};
 
     if (this.ignoreCase) {
       this.caseConverter = s => s.toUpperCase();
@@ -122,7 +123,7 @@ class RuleWalker extends Lint.RuleWalker {
     if (importReduction !== sortedReduction) {
       this.addFailureAtNode(
         node,
-        'Member imports should be sorted.');
+        'Member imports must be sorted alphabetically.');
     }
   }
 

--- a/src/rules/sortImportsRule.ts
+++ b/src/rules/sortImportsRule.ts
@@ -184,23 +184,24 @@ class RuleWalker extends Lint.RuleWalker {
       const noneMatch = /\bimport\s+[\'"]([^"\']+)["\']/g.exec(nodeText);
       const allMatch = /\bimport\s+\*\s+as\s+(.+)\s+from\s+[\'"](?:[^"\']+)["\']/g.exec(nodeText);
 
+      let result;
       if (singleMatch !== null) {
-        return {
+        result = {
           memberSyntaxType: MemberSyntaxType.Single,
           sortValue: singleMatch[1]
         };
       } else if (multipleMatch !== null) {
-        return {
+        result = {
           memberSyntaxType: MemberSyntaxType.Multiple,
           sortValue: multipleMatch[1]
         };
       } else if (noneMatch !== null) {
-        return {
+        result = {
           memberSyntaxType: MemberSyntaxType.None,
           sortValue: noneMatch[1]
         };
       } else if (allMatch !== null) {
-        return {
+        result = {
           memberSyntaxType: MemberSyntaxType.All,
           sortValue: allMatch[1]
         };
@@ -208,6 +209,7 @@ class RuleWalker extends Lint.RuleWalker {
       else {
         this.addFailureAtNode(node, 'Could not determine import type');
       }
+      return result;
     }
   }
 

--- a/src/rules/sortImportsRule.ts
+++ b/src/rules/sortImportsRule.ts
@@ -8,14 +8,17 @@ export class Rule extends Lint.Rules.AbstractRule {
     ruleName: RULE_NAME,
     description: 'enforce sorting import declarations within module',
     rationale: Lint.Utils.dedent`
-            When declaring multiple imports, a sorted list of import declarations make it easier for developers to read the code and find necessary imports later. This rule is purely a matter of style.
+            When declaring multiple imports, a sorted list of import declarations make it easier for developers to 
+            read the code and find necessary imports later. This rule is purely a matter of style.
             
-            This rule checks all import declarations and verifies that all imports are first sorted by the used member syntax and then alphabetically by the first member or alias name.
+            This rule checks all import declarations and verifies that all imports are first sorted by the used member 
+            syntax and then alphabetically by the first member or alias name.
             `,
     optionsDescription: Lint.Utils.dedent`
       - \`"ignore-case"\` does case-insensitive comparisons (default: \`false\`)
       - \`"ignore-member-sort"\` allows members in multiple type imports to occur in any order (default: \`false\`)
-      - \`"member-syntax-sort-order"\` (default: \`["none", "all", "multiple", "single", "alias"]\`); all 5 items must be present in the array, but you can change the order: 
+      - \`"member-syntax-sort-order"\` (default: \`["none", "all", "multiple", "single", "alias"]\`); all 5 items must be 
+      present in the array, but you can change the order: 
         - \`none\` = import module without exported bindings.
         - \`all\` = import all members provided by exported bindings.
         - \`multiple\` = import multiple members.
@@ -89,7 +92,7 @@ class RuleWalker extends Lint.RuleWalker {
     this.ignoreCase = this.hasOption('ignore-case');
     this.ignoreMemberSort = this.hasOption('ignore-member-sort');
     this.expectedOrder = this._processMemberSyntaxSortOrder(optionSet['member-syntax-sort-order']);
-    this.currentSortValue = {sortValue: '', originalValue: ''};
+    this.currentSortValue = { sortValue: '', originalValue: '' };
 
     if (this.ignoreCase) {
       this.caseConverter = s => s.toUpperCase();
@@ -203,7 +206,7 @@ class RuleWalker extends Lint.RuleWalker {
     if (Array.isArray(sortOption) && typeof sortOption[0] === 'string' && sortOption.length === 5) {
       const order: MemberSyntaxType[] = [];
       const usedOptions = {};
-      sortOption.forEach(function (t) {
+      sortOption.forEach((t) => {
         if (usedOptions[t] !== undefined) {
           // Warning: we have seen this one already - skip
         } else {

--- a/src/rules/sortImportsRule.ts
+++ b/src/rules/sortImportsRule.ts
@@ -147,11 +147,11 @@ class RuleWalker extends Lint.RuleWalker {
         this.currentSortValue = this.caseConverter(importData.sortValue);
       }
     } else {
-      const currentSyntaxType = MemberSyntaxType[MemberSyntaxType[importData.memberSyntaxType]];
-      const previousSyntaxType = MemberSyntaxType[MemberSyntaxType[this.expectedOrder[this.currentImportIndex]]];
+      const currentSyntaxType = MemberSyntaxType[importData.memberSyntaxType];
+      const previousSyntaxType = MemberSyntaxType[this.expectedOrder[this.currentImportIndex]];
       this.addFailureAtNode(
         node,
-        `All imports of type ${currentSyntaxType} must occur before all imports of type ${previousSyntaxType}`);
+        `All imports of type "${currentSyntaxType}" must occur before all imports of type "${previousSyntaxType}"`);
     }
   }
 

--- a/src/rules/sortImportsRule.ts
+++ b/src/rules/sortImportsRule.ts
@@ -69,6 +69,14 @@ export class Rule extends Lint.Rules.AbstractRule {
   }
 }
 
+enum MemberSyntaxType {
+  None,
+  All,
+  Multiple,
+  Single,
+  Alias
+}
+
 interface ImportMetadata {
   memberSyntaxType: MemberSyntaxType;
   sortValue: string;
@@ -80,7 +88,7 @@ class RuleWalker extends Lint.RuleWalker {
   private expectedOrder: MemberSyntaxType[];
 
   private currentImportIndex = 0;
-  private currentSortValue: {sortValue: string, originalValue: string};
+  private currentSortValue: { sortValue: string, originalValue: string };
   private caseConverter: (s: string) => string;
 
   constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
@@ -91,7 +99,7 @@ class RuleWalker extends Lint.RuleWalker {
     // this.ignoreCase = optionSet['ignore-case'];
     this.ignoreCase = this.hasOption('ignore-case');
     this.ignoreMemberSort = this.hasOption('ignore-member-sort');
-    this.expectedOrder = this._processMemberSyntaxSortOrder(optionSet['member-syntax-sort-order']);
+    this.expectedOrder = RuleWalker._processMemberSyntaxSortOrder(optionSet['member-syntax-sort-order']);
     this.currentSortValue = { sortValue: '', originalValue: '' };
 
     if (this.ignoreCase) {
@@ -140,7 +148,8 @@ class RuleWalker extends Lint.RuleWalker {
         this.currentImportIndex = index;
         this.currentSortValue = {
           sortValue: this.caseConverter(importData.sortValue),
-          originalValue: importData.sortValue};
+          originalValue: importData.sortValue
+        };
       } else if (this.currentSortValue.sortValue > this.caseConverter(importData.sortValue)) {
         this.addFailureAtNode(
           node,
@@ -148,7 +157,8 @@ class RuleWalker extends Lint.RuleWalker {
       } else {
         this.currentSortValue = {
           sortValue: this.caseConverter(importData.sortValue),
-          originalValue: importData.sortValue};
+          originalValue: importData.sortValue
+        };
       }
     } else {
       const currentSyntaxType = MemberSyntaxType[importData.memberSyntaxType];
@@ -201,9 +211,17 @@ class RuleWalker extends Lint.RuleWalker {
     }
   }
 
-  private _processMemberSyntaxSortOrder(sortOption: string[]): MemberSyntaxType[] {
+  private static _processMemberSyntaxSortOrder(sortOption: string[]): MemberSyntaxType[] {
     const defaultOrder = [MemberSyntaxType.None, MemberSyntaxType.All, MemberSyntaxType.Multiple, MemberSyntaxType.Single, MemberSyntaxType.Alias];
     if (Array.isArray(sortOption) && typeof sortOption[0] === 'string' && sortOption.length === 5) {
+      const memberSyntaxTypeMap = {
+        none: MemberSyntaxType.None,
+        all: MemberSyntaxType.All,
+        multiple: MemberSyntaxType.Multiple,
+        single: MemberSyntaxType.Single,
+        alias: MemberSyntaxType.Alias
+      };
+
       const order: MemberSyntaxType[] = [];
       const usedOptions = {};
       sortOption.forEach((t) => {
@@ -211,22 +229,8 @@ class RuleWalker extends Lint.RuleWalker {
           // Warning: we have seen this one already - skip
         } else {
           usedOptions[t] = t;
-          switch (t) {
-            case 'none':
-              order.push(MemberSyntaxType.None);
-              break;
-            case 'all':
-              order.push(MemberSyntaxType.All);
-              break;
-            case 'multiple':
-              order.push(MemberSyntaxType.Multiple);
-              break;
-            case 'single':
-              order.push(MemberSyntaxType.Single);
-              break;
-            case 'alias':
-              order.push(MemberSyntaxType.Alias);
-              break;
+          if (memberSyntaxTypeMap[t]) {
+            order.push(memberSyntaxTypeMap[t]);
           }
         }
       });
@@ -235,12 +239,4 @@ class RuleWalker extends Lint.RuleWalker {
       return defaultOrder;
     }
   }
-}
-
-enum MemberSyntaxType {
-  None,
-  All,
-  Multiple,
-  Single,
-  Alias
 }

--- a/src/rules/sortImportsRule.ts
+++ b/src/rules/sortImportsRule.ts
@@ -1,0 +1,198 @@
+'use strict';
+
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+
+const RULE_NAME = 'sort-imports';
+
+export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: RULE_NAME,
+    description: 'Requires that imports be sorted per ESLint rules.',
+    descriptionDetails: Lint.Utils.dedent`
+            Enforce a consistent ordering for ES6-style imports:
+            By default, the order is
+            [none, all, multiple, single, alias]
+
+            e.g.
+            import 'module-without-export';
+            import * as foo from 'foo';
+            import * as bar from 'bar';
+            import {alpha, beta} from 'alpha';
+            import {delta, gamma} from 'delta';
+            import {a} from 'baz';
+            import {b} from 'qux';
+            import c = foo.bar.baz;
+            `,
+    optionsDescription: Lint.Utils.dedent`
+      `,
+    options: {
+      type: 'object',
+      properties: {
+        'member-syntax-sort-order': {
+          type: 'array',
+          items: {
+            type: 'string',
+            enum: ['none', 'all', 'multiple', 'single', 'alias']
+          },
+          minLength: 5,
+          maxLength: 5
+        },
+        'ignore-case': {
+          type: 'boolean'
+        },
+        'ignore-member-sort': {
+          type: 'boolean'
+        }
+      }
+    },
+    optionExamples: [
+      Lint.Utils.dedent`
+        "${RULE_NAME}": [true]
+        `,
+      Lint.Utils.dedent`
+        "${RULE_NAME}": [true, {
+        }]
+        `
+    ],
+    typescriptOnly: false,
+    type: 'style'
+  };
+
+  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    const walker = new RuleWalker(sourceFile, this.getOptions());
+    return this.applyWithWalker(walker);
+  }
+}
+
+interface ImportMetadata {
+  memberSyntaxType: MemberSyntaxType;
+  sortValue: string;
+}
+
+class RuleWalker extends Lint.RuleWalker {
+  private ignoreCase: boolean;
+  private ignoreMemberSort: boolean;
+  private expectedOrder: MemberSyntaxType[];
+
+  private currentImportIndex = 0;
+  private currentSortValue: string;
+
+  constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
+    super(sourceFile, options);
+
+    const optionSet = this.getOptions()[0] || {};
+
+    this.ignoreCase = optionSet['ignore-case'];
+    this.ignoreMemberSort = optionSet['ignore-member-sort'];
+    this.expectedOrder = this._processMemberSyntaxSortOrder(optionSet['member-syntax-sort-order']);
+  }
+
+  public visitNode(node: ts.Node) {
+    if (node.kind === ts.SyntaxKind.ImportDeclaration ||
+      node.kind === ts.SyntaxKind.ImportEqualsDeclaration) {
+      this._validateOrder(<ts.ImportDeclaration | ts.ImportEqualsDeclaration>node);
+    }
+    super.visitNode(node);
+  }
+
+  public visitNamedImports(node: ts.NamedImports) {
+    if (!this.ignoreMemberSort) {
+      this._validateMemberSort(node);
+    }
+    super.visitNamedImports(node);
+  }
+
+  private _validateMemberSort(node: ts.NamedImports) {
+  }
+
+  private _validateOrder(node: ts.ImportDeclaration | ts.ImportEqualsDeclaration) {
+    const importData = this._determineImportType(node);
+
+    // See if the import type is still available
+    const index = this.expectedOrder.indexOf(importData.memberSyntaxType, this.currentImportIndex);
+    if (index !== -1) {
+      if (this.expectedOrder[this.currentImportIndex] !== importData.memberSyntaxType) {
+        this.currentImportIndex = index;
+      }
+    } else {
+      this.addFailureAtNode(
+        node,
+        `All imports of type ${importData} must occur before all imports of type ${this.expectedOrder[this.currentImportIndex]}`);
+    }
+  }
+
+  private _determineImportType(node: ts.ImportDeclaration | ts.ImportEqualsDeclaration): ImportMetadata {
+    const nodeText = node.getFullText();
+
+    if (node.kind === ts.SyntaxKind.ImportEqualsDeclaration) {
+      const aliasMatch = /\bimport\s+(\w+)\s*=.+/g.exec(nodeText);
+      return {
+        memberSyntaxType: MemberSyntaxType.Single,
+        sortValue: aliasMatch[1]
+      };
+    } else {
+      const singleMatch = /\bimport\s+({?([^,]+?)}?)\s*from\s+[\'"](?:[^"\']+)["\']/g.exec(nodeText);
+      const multipleMatch = /\bimport\s+{(?:\s*(.+)\s*,)\s*.+}\s*from\s+[\'"](?:[^"\']+)["\']/g.exec(nodeText);
+      const noneMatch = /\bimport\s+[\'"]([^"\']+)["\']/g.exec(nodeText);
+      if (singleMatch !== null) {
+        return {
+          memberSyntaxType: MemberSyntaxType.Single,
+          sortValue: singleMatch[1]
+        };
+      } else if (multipleMatch !== null) {
+        return {
+          memberSyntaxType: MemberSyntaxType.Multiple,
+          sortValue: multipleMatch[1]
+        };
+      } else if (noneMatch !== null) {
+        return {
+          memberSyntaxType: MemberSyntaxType.None,
+          sortValue: noneMatch[1]
+        };
+      }
+    }
+  }
+
+  private _processMemberSyntaxSortOrder(sortOption: string[]): MemberSyntaxType[] {
+    const defaultOrder = [MemberSyntaxType.None, MemberSyntaxType.All, MemberSyntaxType.Multiple, MemberSyntaxType.Single, MemberSyntaxType.Alias];
+    if (Array.isArray(sortOption) && typeof sortOption[0] === 'string' && sortOption.length === 5) {
+      const order: MemberSyntaxType[] = [];
+      const usedOptions = {};
+      for (let t in sortOption) {
+        if (usedOptions[t] !== undefined) {
+          // Warning: we have seen this one already - skip
+        } else {
+          usedOptions[t] = t;
+          switch (t) {
+            case 'none':
+              order.push(MemberSyntaxType.None);
+              break;
+            case 'all':
+              order.push(MemberSyntaxType.All);
+              break;
+            case 'multiple':
+              order.push(MemberSyntaxType.Multiple);
+              break;
+            case 'single':
+              order.push(MemberSyntaxType.Single);
+              break;
+            case 'alias':
+              order.push(MemberSyntaxType.Alias);
+              break;
+          }
+        }
+      }
+    } else {
+      return defaultOrder;
+    }
+  }
+}
+
+enum MemberSyntaxType {
+  None,
+  All,
+  Multiple,
+  Single,
+  Alias
+}

--- a/src/rules/sortImportsRule.ts
+++ b/src/rules/sortImportsRule.ts
@@ -150,7 +150,7 @@ class RuleWalker extends Lint.RuleWalker {
         sortValue: aliasMatch[1]
       };
     } else {
-      const singleMatch = /\bimport\s+({?([^,\*]+?)}?)\s*from\s+[\'"](?:[^"\']+)["\']/g.exec(nodeText);
+      const singleMatch = /\bimport\s+({?([^,{}\*]+?)}?)\s*from\s+[\'"](?:[^"\']+)["\']/g.exec(nodeText);
       const multipleMatch = /\bimport\s+{(?:\s*(.+)\s*,)\s*.+}\s*from\s+[\'"](?:[^"\']+)["\']/g.exec(nodeText);
       const noneMatch = /\bimport\s+[\'"]([^"\']+)["\']/g.exec(nodeText);
       const allMatch = /\bimport\s+\*\s+as\s+(.+)\s+from\s+[\'"](?:[^"\']+)["\']/g.exec(nodeText);
@@ -175,6 +175,9 @@ class RuleWalker extends Lint.RuleWalker {
           memberSyntaxType: MemberSyntaxType.All,
           sortValue: allMatch[1]
         };
+      }
+      else {
+        this.addFailureAtNode(node, 'Could not determine import type');
       }
     }
   }

--- a/src/test/rules/sortImportsRuleTests.ts
+++ b/src/test/rules/sortImportsRuleTests.ts
@@ -19,7 +19,7 @@ function expecting(errors): Failure[] {
 }
 
 function formatString(input: string, ...args): string {
-  return input.replace(/\{\{|\}\}|\{(\d+)\}/g, function (m, n) {
+  return input.replace(/\{\{|\}\}|\{(\d+)\}/g, (m, n) => {
     if (m === '{{') { return '{'; }
     if (m === '}}') { return '}'; }
     return args[n];

--- a/src/test/rules/sortImportsRuleTests.ts
+++ b/src/test/rules/sortImportsRuleTests.ts
@@ -29,8 +29,7 @@ ruleTester.addTestGroup('valid', 'should pass ESLint valid tests', [
     import * as B from 'foo';
     import {a, b} from 'bar';`,
   {
-    code:
-    dedent`
+    code: dedent`
       import A from 'bar';
       import {b, c} from 'foo'`,
     options: [{ 'member-syntax-sort-order': ['single', 'multiple', 'none', 'all', 'alias'] }]
@@ -59,10 +58,7 @@ ruleTester.addTestGroup('valid', 'should pass ESLint valid tests', [
       import B from 'bar';`,
     options: ['ignore-case']
   },
-  {
-    code:
-    `import {a, b, c, d} from 'foo';`
-  },
+  `import {a, b, c, d} from 'foo';`,
   {
     code: `import {b, A, C, d} from 'foo';`,
     options: ['ignore-member-sort']
@@ -75,21 +71,14 @@ ruleTester.addTestGroup('valid', 'should pass ESLint valid tests', [
     code: `import {a, B, c, D} from 'foo';`,
     options: ['ignore-case']
   },
-  {
-    code:
-    `import a, * as b from 'foo';`
-  },
-  {
-    code: dedent`
-      import * as a from 'foo';
+  `import a, * as b from 'foo';`,
+  dedent`
+    import * as a from 'foo';
 
-      import b from 'bar';`
-  },
-  {
-    code: dedent`
-      import * as bar from 'bar';
-      import * as foo from 'foo';`
-  },
+    import b from 'bar';`,
+  dedent`
+    import * as bar from 'bar';
+    import * as foo from 'foo';`,
   {
     code: dedent`
       import 'foo';
@@ -175,15 +164,15 @@ ruleTester.addTestGroup('invalid', 'should fail ESLint invalid tests', [
   },
   {
     code: dedent`
-              import {
-                boop,
-                foo,
-                zoo,
-                baz as qux,
-                bar,
-                beep
-              } from 'foo';
-            `,
+      import {
+        boop,
+        foo,
+        zoo,
+        baz as qux,
+        bar,
+        beep
+      } from 'foo';
+    `,
     errors: [{
       failure: MEMBER_SORT_ERROR,
       startPosition: new Position(1, 7),

--- a/src/test/rules/sortImportsRuleTests.ts
+++ b/src/test/rules/sortImportsRuleTests.ts
@@ -1,27 +1,39 @@
-import { RuleTester, Failure, Position, dedent } from './ruleTester';
+/// <reference path='../../../typings/mocha/mocha.d.ts' />
+import { makeTest } from './helper';
 
-const ruleTester = new RuleTester('sort-imports');
+const rule = 'sort-imports';
+const scripts = {
+  defaultMemberOrder: {
+    valid: [
+      `import "test"`,
 
-function expecting(errors: string[]]): Failure[] {
-  return errors.map((err) => {
-    let message = '';
-    return {
-      failure: message,
-      startPosition: new Position(err[0]),
-      endPosition: new Position()
-    };
-  });
-}
+      `import "test"
+      import {foo} from "bar"`,
 
-ruleTester.addTestGroup('group-name', 'should ...', [
-  {
-    code: dedent`
-     // code goes here
-     `,
-    options: [],
-    errors: expecting([
-    ])
+      `import {foo} from "bar"`,
+
+      `import "blah";
+      import * as bah from "buz";
+      import {foo, gar} from "bar";
+      import {fuz} from "baz";
+      import a = b.blah`
+
+    ],
+    invalid: [
+      `import {foo} from "bar";
+      import {bar, baz} from "buz";`
+    ]
   }
-]);
+};
 
-ruleTester.runTests();
+describe(rule, function test() {
+  const defaultMemberOrderConfig = { rules: { 'sort-imports': true } };
+
+  it('should pass when "defaultMemberOrder"', function testVariables() {
+    makeTest(rule, scripts.defaultMemberOrder.valid, true, defaultMemberOrderConfig);
+  });
+
+  it('should fail when "defaultMemberOrder"', function testVariables() {
+    makeTest(rule, scripts.defaultMemberOrder.invalid, false, defaultMemberOrderConfig);
+  });
+});

--- a/src/test/rules/sortImportsRuleTests.ts
+++ b/src/test/rules/sortImportsRuleTests.ts
@@ -159,7 +159,7 @@ ruleTester.addTestGroup('invalid', 'should fail ESLint invalid tests', [
   },
   {
     code: `import {zzzzz, /* comment */ aaaaa} from 'foo';`,
-    errors: expecting([[MEMBER_SORT_ERROR,  0, 7, 35]])
+    errors: expecting([[MEMBER_SORT_ERROR, 0, 7, 35]])
   },
   {
     code: `import {zzzzz /* comment */, aaaaa} from 'foo';`,

--- a/src/test/rules/sortImportsRuleTests.ts
+++ b/src/test/rules/sortImportsRuleTests.ts
@@ -1,63 +1,62 @@
-// import { Failure, Position, RuleTester, dedent } from './ruleTester';
+import { Failure, Position, RuleTester, dedent } from './ruleTester';
 
-import { Failure, Position, RuleTester } from './ruleTester';
-
-const ALPHA_ORDER_ERROR = 'All imports of the same type must be sorted alphabetically. "{0}" must come before "{1}"';
-const TYPE_ORDER_ERROR = 'All imports of type "{0}" must occur before all imports of type "{1}"';
+const ALPHA_ORDER_ERROR = (x, y) => `All imports of the same type must be sorted alphabetically. "${x}" must come before "${y}"`;
+const TYPE_ORDER_ERROR = (x, y) => `All imports of type "${x}" must occur before all imports of type "${y}"`;
 const MEMBER_SORT_ERROR = 'Member imports must be sorted alphabetically.';
 
-function expecting(errors): Failure[] {
+function expecting(errors: [string, number, number, number][]): Failure[] {
+  // message, line, startColumn, endColumn
   return errors.map((err) => {
-    if (err.message && err.startColumn && err.endColumn) {
-      return {
-        failure: err.message,
-        startPosition: new Position(err.line, err.startColumn),
-        endPosition: new Position(err.line, err.endColumn)
-      };
-    }
+    return {
+      failure: err[0],
+      startPosition: new Position(err[1], err[2]),
+      endPosition: new Position(err[1], err[3])
+    };
   });
 }
-
-function formatString(input: string, ...args): string {
-  return input.replace(/\{\{|\}\}|\{(\d+)\}/g, (m, n) => {
-    if (m === '{{') { return '{'; }
-    if (m === '}}') { return '}'; }
-    return args[n];
-  });
-};
 
 const ruleTester = new RuleTester('sort-imports');
 
 ruleTester.addTestGroup('valid', 'should pass ESLint valid tests', [
-  `import a from 'foo';
-           import b from 'bar';
-           import c from 'baz';`,
-  `import * as B from 'foo';
-           import A from 'bar';`,
-  `import * as B from 'foo';
-           import {a, b} from 'bar';`,
+  dedent`
+    import a from 'foo';
+    import b from 'bar';
+    import c from 'baz';`,
+  dedent`
+    import * as B from 'foo';
+    import A from 'bar';`,
+  dedent`
+    import * as B from 'foo';
+    import {a, b} from 'bar';`,
   {
     code:
-    `import A from 'bar';
-           import {b, c} from 'foo'`,
+    dedent`
+      import A from 'bar';
+      import {b, c} from 'foo'`,
     options: [{ 'member-syntax-sort-order': ['single', 'multiple', 'none', 'all', 'alias'] }]
   },
-  `import {a, b} from 'bar';
-        import {c, d} from 'foo';`,
-  `import A from 'foo';
-        import B from 'bar';`,
-  `import A from 'foo';
-        import a from 'bar';`,
-  `import a, * as b from 'foo';
-        import c from 'bar';`,
-  `import 'foo';
-        import a from 'bar';`,
-  `import B from 'foo.js';
-        import a from 'bar';`,
+  dedent`
+    import {a, b} from 'bar';
+    import {c, d} from 'foo';`,
+  dedent`
+    import A from 'foo';
+    import B from 'bar';`,
+  dedent`
+    import A from 'foo';
+    import a from 'bar';`,
+  dedent`
+    import a, * as b from 'foo';
+    import c from 'bar';`,
+  dedent`
+    import 'foo';
+    import a from 'bar';`,
+  dedent`
+    import B from 'foo.js';
+    import a from 'bar';`,
   {
-    code:
-    `import a from 'foo';
-        import B from 'bar';`,
+    code: dedent`
+      import a from 'foo';
+      import B from 'bar';`,
     options: ['ignore-case']
   },
   {
@@ -81,20 +80,20 @@ ruleTester.addTestGroup('valid', 'should pass ESLint valid tests', [
     `import a, * as b from 'foo';`
   },
   {
-    code:
-    `import * as a from 'foo';
+    code: dedent`
+      import * as a from 'foo';
 
-        import b from 'bar';`
+      import b from 'bar';`
   },
   {
-    code:
-    `import * as bar from 'bar';
-        import * as foo from 'foo';`
+    code: dedent`
+      import * as bar from 'bar';
+      import * as foo from 'foo';`
   },
   {
-    code:
-    `import 'foo';
-        import bar from 'bar';`,
+    code: dedent`
+      import 'foo';
+      import bar from 'bar';`,
     options: ['ignore-case']
   },
   `import React, {Component} from 'react';`
@@ -102,73 +101,80 @@ ruleTester.addTestGroup('valid', 'should pass ESLint valid tests', [
 
 ruleTester.addTestGroup('invalid', 'should fail ESLint invalid tests', [
   {
-    code: `import a from 'foo';
-        import A from 'bar';`,
-    errors: expecting([{ message: formatString(ALPHA_ORDER_ERROR, 'A', 'a'), line: 1, startColumn: 8, endColumn: 28 }])
+    code: dedent`
+      import a from 'foo';
+      import A from 'bar';`,
+    errors: expecting([[ALPHA_ORDER_ERROR('A', 'a'), 2, 0, 20]])
   },
   {
-    code: `import b from 'foo';
-        import a from 'bar';`,
-    errors: expecting([{ message: formatString(ALPHA_ORDER_ERROR, 'a', 'b'), line: 1, startColumn: 8, endColumn: 28 }])
+    code: dedent`
+      import b from 'foo';
+      import a from 'bar';`,
+    errors: expecting([[ALPHA_ORDER_ERROR('a', 'b'), 2, 0, 20]])
   },
   {
-    code: `import {b, c} from 'foo';
-        import {a, d} from 'bar';`,
-    errors: expecting([{ message: formatString(ALPHA_ORDER_ERROR, 'a', 'b'), line: 1, startColumn: 8, endColumn: 33 }])
+    code: dedent`
+      import {b, c} from 'foo';
+      import {a, d} from 'bar';`,
+    errors: expecting([[ALPHA_ORDER_ERROR('a', 'b'), 2, 0, 25]])
   },
   {
-    code: `import * as foo from 'foo'
-        import * as bar from 'bar';`,
-    errors: expecting([{ message: formatString(ALPHA_ORDER_ERROR, 'bar', 'foo'), line: 1, startColumn: 8, endColumn: 35 }])
+    code: dedent`
+      import * as foo from 'foo'
+      import * as bar from 'bar';`,
+    errors: expecting([[ALPHA_ORDER_ERROR('bar', 'foo'), 2, 0, 27]])
   },
   {
-    code: `import a from 'foo';
-        import {b, c} from 'bar';`,
-    errors: expecting([{ message: formatString(TYPE_ORDER_ERROR, 'Multiple', 'Single'), line: 1, startColumn: 8, endColumn: 33 }])
+    code: dedent`
+      import a from 'foo';
+      import {b, c} from 'bar';`,
+    errors: expecting([[TYPE_ORDER_ERROR('Multiple', 'Single'), 2, 0, 25]])
   },
   {
-    code: `import a from 'foo';
-        import * as b from 'bar';`,
-    errors: expecting([{ message: formatString(TYPE_ORDER_ERROR, 'All', 'Single'), line: 1, startColumn: 8, endColumn: 33 }])
+    code: dedent`
+      import a from 'foo';
+      import * as b from 'bar';`,
+    errors: expecting([[TYPE_ORDER_ERROR('All', 'Single'), 2, 0, 25]])
   },
   {
-    code: `import a from 'foo';
-        import 'bar';`,
-    errors: expecting([{ message: formatString(TYPE_ORDER_ERROR, 'None', 'Single'), line: 1, startColumn: 8, endColumn: 21 }])
+    code: dedent`
+      import a from 'foo';
+      import 'bar';`,
+    errors: expecting([[TYPE_ORDER_ERROR('None', 'Single'), 2, 0, 13]])
   },
   {
-    code:
-    `import b from 'bar';
-        import * as a from 'foo';`,
+    code: dedent`
+      import b from 'bar';
+      import * as a from 'foo';`,
     options: [{ 'member-syntax-sort-order': ['all', 'single', 'multiple', 'none', 'alias'] }],
-    errors: expecting([{ message: formatString(TYPE_ORDER_ERROR, 'All', 'Single'), line: 1, startColumn: 8, endColumn: 33 }])
+    errors: expecting([[TYPE_ORDER_ERROR('All', 'Single'), 2, 0, 25]])
   },
   {
     code: `import {b, a, d, c} from 'foo';`,
-    errors: expecting([{ message: MEMBER_SORT_ERROR, line: 0, startColumn: 7, endColumn: 19 }])
+    errors: expecting([[MEMBER_SORT_ERROR, 0, 7, 19]])
   },
   {
     code: `import {a, B, c, D} from 'foo';`,
-    errors: expecting([{ message: MEMBER_SORT_ERROR, line: 0, startColumn: 7, endColumn: 19 }])
+    errors: expecting([[MEMBER_SORT_ERROR, 0, 7, 19]])
   },
   {
     code: `import {zzzzz, /* comment */ aaaaa} from 'foo';`,
-    errors: expecting([{ message: MEMBER_SORT_ERROR, line: 0, startColumn: 7, endColumn: 35 }])
+    errors: expecting([[MEMBER_SORT_ERROR,  0, 7, 35]])
   },
   {
     code: `import {zzzzz /* comment */, aaaaa} from 'foo';`,
-    errors: expecting([{ message: MEMBER_SORT_ERROR, line: 0, startColumn: 7, endColumn: 35 }])
+    errors: expecting([[MEMBER_SORT_ERROR, 0, 7, 35]])
   },
   {
     code: `import {/* comment */ zzzzz, aaaaa} from 'foo';`,
-    errors: expecting([{ message: MEMBER_SORT_ERROR, line: 0, startColumn: 7, endColumn: 35 }])
+    errors: expecting([[MEMBER_SORT_ERROR, 0, 7, 35]])
   },
   {
     code: `import {zzzzz, aaaaa /* comment */} from 'foo';`,
-    errors: expecting([{ message: MEMBER_SORT_ERROR, line: 0, startColumn: 7, endColumn: 35 }])
+    errors: expecting([[MEMBER_SORT_ERROR, 0, 7, 35]])
   },
   {
-    code: `
+    code: dedent`
               import {
                 boop,
                 foo,
@@ -180,8 +186,8 @@ ruleTester.addTestGroup('invalid', 'should fail ESLint invalid tests', [
             `,
     errors: [{
       failure: MEMBER_SORT_ERROR,
-      startPosition: new Position(1, 21),
-      endPosition: new Position(8, 15)
+      startPosition: new Position(1, 7),
+      endPosition: new Position(8, 1)
     }]
   }
 ]);

--- a/src/test/rules/sortImportsRuleTests.ts
+++ b/src/test/rules/sortImportsRuleTests.ts
@@ -192,4 +192,30 @@ ruleTester.addTestGroup('invalid', 'should fail ESLint invalid tests', [
   }
 ]);
 
+ruleTester.addTestGroup('alias', 'should pass alias tests', [
+  `import a = A.a;`,
+  dedent`
+    import x from 'foo';
+    import y = x.y;`,
+  {
+    code: dedent`
+      import x = y.x;
+      import a from 'foo';`,
+    errors: expecting([[TYPE_ORDER_ERROR('Single', 'Alias'), 2, 0, 20]])
+  },
+  {
+    code: dedent`
+      import x = y.x;
+      import a from 'foo';`,
+    options: [{ 'member-syntax-sort-order': ['alias', 'all', 'single', 'multiple', 'none'] }]
+  },
+  {
+    code: dedent`
+      import a from 'foo';
+      import x = y.x;`,
+    options: [{ 'member-syntax-sort-order': ['alias', 'all', 'single', 'multiple', 'none'] }],
+    errors: expecting([[TYPE_ORDER_ERROR('Alias', 'Single'), 2, 0, 15]])
+  }
+]);
+
 ruleTester.runTests();

--- a/src/test/rules/sortImportsRuleTests.ts
+++ b/src/test/rules/sortImportsRuleTests.ts
@@ -1,39 +1,199 @@
 /// <reference path='../../../typings/mocha/mocha.d.ts' />
-import { makeTest } from './helper';
+/// <reference path='../../../typings/chai/chai.d.ts' />
 
-const rule = 'sort-imports';
+import { expect } from 'chai';
+import { testScript } from './helper';
+
+const ruleName = 'sort-imports';
 const scripts = {
+  eslintParityDefaults: {
+    valid: [
+      {
+        code:
+        `import a from 'foo';
+           import b from 'bar';
+           import c from 'baz';`
+      },
+      {
+        code:
+        `import * as B from 'foo';
+           import A from 'bar';`
+      },
+      {
+        code:
+        `import * as B from 'foo';
+           import {a, b} from 'bar';`
+      },
+      {
+        code:
+        `import A from 'bar';
+           import {b, c} from 'foo'`,
+        rules: {
+          'sort-imports': true,
+          memberSyntaxSortOrder: ['single', 'multiple', 'none', 'all', 'alias']
+        }
+      },
+      {
+        code:
+        `import {a, b} from 'bar';
+        import {c, d} from 'foo';`
+      },
+      {
+        code:
+        `import A from 'foo';
+        import B from 'bar';`
+      },
+      {
+        code:
+        `import A from 'foo';
+        import a from 'bar';`
+      },
+      {
+        code:
+        `import a, * as b from 'foo';
+        import c from 'bar';`
+      },
+      {
+        code:
+        `import 'foo';
+        import a from 'bar';`
+      },
+      {
+        code:
+        `import B from 'foo.js';
+        import a from 'bar';`
+      },
+      {
+        code:
+        `import a from 'foo';
+        import B from 'bar';`,
+        rules: {
+          'sort-imports': true,
+          'ignore-case': true
+        }
+      },
+      {
+        code:
+        `import {a, b, c, d} from 'foo';`
+      },
+      {
+        code: `import {b, A, C, d} from 'foo';`,
+        rules: {
+          'sort-imports': true,
+          'ignore-member-sort': true
+        }
+      },
+      {
+        code: `import {B, a, C, d} from 'foo';`,
+        rules: {
+          'sort-imports': true,
+          'ignore-member-sort': true
+        }
+      },
+      {
+        code: `import {a, B, c, D} from 'foo';`,
+        rules: {
+          'sort-imports': true,
+          'ignore-case': true
+        }
+      },
+      // Not supporting this format at this time.
+      // {
+      //   code:
+      //   `import a, * as b from 'foo';`
+      // },
+      {
+        code:
+        `import * as a from 'foo';
+
+        import b from 'bar';`
+      },
+      {
+        code:
+        `import * as bar from 'bar';
+        import * as foo from 'foo';`
+      },
+      {
+        code:
+        `import 'foo';
+        import bar from 'bar';`,
+        rules: {
+          'sort-imports': true,
+          'ignore-case': true
+        }
+      },
+      {
+        code:
+        `import React, {Component} from 'react';`
+      }
+    ]
+  },
   defaultMemberOrder: {
     valid: [
-      `import "test"`,
-
-      `import "test"
-      import {foo} from "bar"`,
-
-      `import {foo} from "bar"`,
-
-      `import "blah";
-      import * as bah from "buz";
-      import {foo, gar} from "bar";
-      import {fuz} from "baz";
-      import a = b.blah`
-
+      {
+        code:
+        `import "test"`
+      },
+      {
+        code:
+        `import "test"
+       import {foo} from "bar"`
+      },
+      {
+        code:
+        `import {foo} from "bar"`
+      }
+      ,
+      {
+        code:
+        `import "blah";
+       import * as bah from "buz";
+       import {foo, gar} from "bar";
+       import {fuz} from "baz";
+       import a = b.blah`
+      }
     ],
     invalid: [
-      `import {foo} from "bar";
+      {
+        code:
+        `import {foo} from "bar";
       import {bar, baz} from "buz";`
+      }
     ]
   }
 };
 
-describe(rule, function test() {
+describe(ruleName, function test() {
   const defaultMemberOrderConfig = { rules: { 'sort-imports': true } };
 
+  it('should pass valid ESLint default setting parity tests', function testVariables() {
+    makeTest(ruleName, scripts.eslintParityDefaults.valid, true, defaultMemberOrderConfig);
+  });
+
+  // it('should fail invalid ESLint default setting parity tests', function testVariables() {
+  //   makeTest(ruleName, scripts.eslintParityDefaults.invalid, false, defaultMemberOrderConfig);
+  // });
+
   it('should pass when "defaultMemberOrder"', function testVariables() {
-    makeTest(rule, scripts.defaultMemberOrder.valid, true, defaultMemberOrderConfig);
+    makeTest(ruleName, scripts.defaultMemberOrder.valid, true, defaultMemberOrderConfig);
   });
 
   it('should fail when "defaultMemberOrder"', function testVariables() {
-    makeTest(rule, scripts.defaultMemberOrder.invalid, false, defaultMemberOrderConfig);
+    makeTest(ruleName, scripts.defaultMemberOrder.invalid, false, defaultMemberOrderConfig);
   });
 });
+
+function makeTest(rule: string, codeFragment: Array<{ code: string, rules?: {} }>, expected: boolean, defaultConfig?: { rules: {} }) {
+  if (!defaultConfig) {
+    defaultConfig = {
+      rules: {}
+    };
+
+    defaultConfig.rules[rule] = true;
+  }
+
+  codeFragment.forEach((code) => {
+    const res = testScript(rule, code.code, code.rules || defaultConfig);
+    expect(res).to.equal(expected, code.code);
+  });
+}

--- a/src/test/rules/sortImportsRuleTests.ts
+++ b/src/test/rules/sortImportsRuleTests.ts
@@ -29,8 +29,10 @@ const scripts = {
         `import A from 'bar';
            import {b, c} from 'foo'`,
         rules: {
-          'sort-imports': true,
-          memberSyntaxSortOrder: ['single', 'multiple', 'none', 'all', 'alias']
+          'sort-imports': [
+            true,
+            { 'member-syntax-sort-order': ['single', 'multiple', 'none', 'all', 'alias'] }
+          ]
         }
       },
       {
@@ -68,8 +70,8 @@ const scripts = {
         `import a from 'foo';
         import B from 'bar';`,
         rules: {
-          'sort-imports': true,
-          'ignore-case': true
+          'sort-imports': [true,
+            'ignore-case']
         }
       },
       {
@@ -79,29 +81,28 @@ const scripts = {
       {
         code: `import {b, A, C, d} from 'foo';`,
         rules: {
-          'sort-imports': true,
-          'ignore-member-sort': true
+          'sort-imports': [true,
+            'ignore-member-sort']
         }
       },
       {
         code: `import {B, a, C, d} from 'foo';`,
         rules: {
-          'sort-imports': true,
-          'ignore-member-sort': true
+          'sort-imports': [true,
+            'ignore-member-sort']
         }
       },
       {
         code: `import {a, B, c, D} from 'foo';`,
         rules: {
-          'sort-imports': true,
-          'ignore-case': true
+          'sort-imports': [true,
+            'ignore-case']
         }
       },
-      // Not supporting this format at this time.
-      // {
-      //   code:
-      //   `import a, * as b from 'foo';`
-      // },
+      {
+        code:
+        `import a, * as b from 'foo';`
+      },
       {
         code:
         `import * as a from 'foo';
@@ -118,68 +119,105 @@ const scripts = {
         `import 'foo';
         import bar from 'bar';`,
         rules: {
-          'sort-imports': true,
-          'ignore-case': true
+          'sort-imports': [true,
+            'ignore-case']
         }
       },
       {
         code:
         `import React, {Component} from 'react';`
       }
-    ]
-  },
-  defaultMemberOrder: {
-    valid: [
-      {
-        code:
-        `import "test"`
-      },
-      {
-        code:
-        `import "test"
-       import {foo} from "bar"`
-      },
-      {
-        code:
-        `import {foo} from "bar"`
-      }
-      ,
-      {
-        code:
-        `import "blah";
-       import * as bah from "buz";
-       import {foo, gar} from "bar";
-       import {fuz} from "baz";
-       import a = b.blah`
-      }
     ],
     invalid: [
       {
         code:
-        `import {foo} from "bar";
-      import {bar, baz} from "buz";`
+        `import a from 'foo';
+        import A from 'bar';`
+      },
+      {
+        code:
+        `import b from 'foo';
+        import a from 'bar';`
+      },
+      {
+        code:
+        `import {b, c} from 'foo';
+        import {a, d} from 'bar';`
+      },
+      {
+        code:
+        `import * as foo from 'foo'
+        import * as bar from 'bar';`
+      },
+      {
+        code:
+        `import a from 'foo';
+        import {b, c} from 'bar';`
+      },
+      {
+        code:
+        `import a from 'foo';
+        import * as b from 'bar';`
+      },
+      {
+        code:
+        `import a from 'foo';
+        import 'bar';`
+      },
+      {
+        code:
+        `import b from 'bar';
+        import * as a from 'foo';`,
+        rules: {
+          'sort-imports': [
+            true,
+            { 'member-syntax-sort-order': ['all', 'single', 'multiple', 'none', 'alias'] }
+          ]
+        }
+      },
+      {
+        code: `import {b, a, d, c} from 'foo';`
+      },
+      {
+        code: `import {a, B, c, D} from 'foo';`
+      },
+      {
+        code: `import {zzzzz, /* comment */ aaaaa} from 'foo';`
+      },
+      {
+        code: `import {zzzzz /* comment */, aaaaa} from 'foo';`
+      },
+      {
+        code: `import {/* comment */ zzzzz, aaaaa} from 'foo';`
+      },
+      {
+        code: `import {zzzzz, aaaaa /* comment */} from 'foo';`
+      },
+      {
+        code: `
+              import {
+                boop,
+                foo,
+                zoo,
+                baz as qux,
+                bar,
+                beep
+              } from 'foo';
+            `
       }
     ]
   }
 };
 
 describe(ruleName, function test() {
-  const defaultMemberOrderConfig = { rules: { 'sort-imports': true } };
+  const defaultConfig = { rules: { 'sort-imports': true } };
 
-  it('should pass valid ESLint default setting parity tests', function testVariables() {
-    makeTest(ruleName, scripts.eslintParityDefaults.valid, true, defaultMemberOrderConfig);
+  it('should pass valid ESLint parity tests', function testVariables() {
+    makeTest(ruleName, scripts.eslintParityDefaults.valid, true, defaultConfig);
   });
 
-  // it('should fail invalid ESLint default setting parity tests', function testVariables() {
-  //   makeTest(ruleName, scripts.eslintParityDefaults.invalid, false, defaultMemberOrderConfig);
-  // });
-
-  it('should pass when "defaultMemberOrder"', function testVariables() {
-    makeTest(ruleName, scripts.defaultMemberOrder.valid, true, defaultMemberOrderConfig);
-  });
-
-  it('should fail when "defaultMemberOrder"', function testVariables() {
-    makeTest(ruleName, scripts.defaultMemberOrder.invalid, false, defaultMemberOrderConfig);
+  it('should fail invalid ESLint parity tests', function testVariables() {
+    makeTest(ruleName, scripts.eslintParityDefaults.invalid, false, defaultConfig);
   });
 });
 
@@ -193,7 +231,7 @@ function makeTest(rule: string, codeFragment: Array<{ code: string, rules?: {} }
   }
 
   codeFragment.forEach((code) => {
-    const res = testScript(rule, code.code, code.rules || defaultConfig);
+    const res = testScript(rule, code.code, code.rules ? { rules: code.rules } : defaultConfig);
     expect(res).to.equal(expected, code.code);
   });
 }

--- a/src/test/rules/sortImportsRuleTests.ts
+++ b/src/test/rules/sortImportsRuleTests.ts
@@ -1,200 +1,174 @@
-/// <reference path='../../../typings/mocha/mocha.d.ts' />
-/// <reference path='../../../typings/chai/chai.d.ts' />
+// import { Failure, Position, RuleTester, dedent } from './ruleTester';
 
-import { expect } from 'chai';
-import { testScript } from './helper';
+import { Failure, Position, RuleTester } from './ruleTester';
 
-const ruleName = 'sort-imports';
-const scripts = {
-  eslintParityDefaults: {
-    valid: [
-      {
-        code:
-        `import a from 'foo';
+const ALPHA_ORDER_ERROR = 'All imports of the same type must be sorted alphabetically. "{0}" must come before "{1}"';
+const TYPE_ORDER_ERROR = 'All imports of type "{0}" must occur before all imports of type "{1}"';
+const MEMBER_SORT_ERROR = 'Member imports must be sorted alphabetically.';
+
+function expecting(errors): Failure[] {
+  return errors.map((err) => {
+    if (err.message && err.startColumn && err.endColumn) {
+      return {
+        failure: err.message,
+        startPosition: new Position(err.line, err.startColumn),
+        endPosition: new Position(err.line, err.endColumn)
+      };
+    }
+  });
+}
+
+function formatString(input: string, ...args): string {
+  return input.replace(/\{\{|\}\}|\{(\d+)\}/g, function (m, n) {
+    if (m === '{{') { return '{'; }
+    if (m === '}}') { return '}'; }
+    return args[n];
+  });
+};
+
+const ruleTester = new RuleTester('sort-imports');
+
+ruleTester.addTestGroup('valid', 'should pass ESLint valid tests', [
+  `import a from 'foo';
            import b from 'bar';
-           import c from 'baz';`
-      },
-      {
-        code:
-        `import * as B from 'foo';
-           import A from 'bar';`
-      },
-      {
-        code:
-        `import * as B from 'foo';
-           import {a, b} from 'bar';`
-      },
-      {
-        code:
-        `import A from 'bar';
+           import c from 'baz';`,
+  `import * as B from 'foo';
+           import A from 'bar';`,
+  `import * as B from 'foo';
+           import {a, b} from 'bar';`,
+  {
+    code:
+    `import A from 'bar';
            import {b, c} from 'foo'`,
-        rules: {
-          'sort-imports': [
-            true,
-            { 'member-syntax-sort-order': ['single', 'multiple', 'none', 'all', 'alias'] }
-          ]
-        }
-      },
-      {
-        code:
-        `import {a, b} from 'bar';
-        import {c, d} from 'foo';`
-      },
-      {
-        code:
-        `import A from 'foo';
-        import B from 'bar';`
-      },
-      {
-        code:
-        `import A from 'foo';
-        import a from 'bar';`
-      },
-      {
-        code:
-        `import a, * as b from 'foo';
-        import c from 'bar';`
-      },
-      {
-        code:
-        `import 'foo';
-        import a from 'bar';`
-      },
-      {
-        code:
-        `import B from 'foo.js';
-        import a from 'bar';`
-      },
-      {
-        code:
-        `import a from 'foo';
+    options: [{ 'member-syntax-sort-order': ['single', 'multiple', 'none', 'all', 'alias'] }]
+  },
+  `import {a, b} from 'bar';
+        import {c, d} from 'foo';`,
+  `import A from 'foo';
         import B from 'bar';`,
-        rules: {
-          'sort-imports': [true,
-            'ignore-case']
-        }
-      },
-      {
-        code:
-        `import {a, b, c, d} from 'foo';`
-      },
-      {
-        code: `import {b, A, C, d} from 'foo';`,
-        rules: {
-          'sort-imports': [true,
-            'ignore-member-sort']
-        }
-      },
-      {
-        code: `import {B, a, C, d} from 'foo';`,
-        rules: {
-          'sort-imports': [true,
-            'ignore-member-sort']
-        }
-      },
-      {
-        code: `import {a, B, c, D} from 'foo';`,
-        rules: {
-          'sort-imports': [true,
-            'ignore-case']
-        }
-      },
-      {
-        code:
-        `import a, * as b from 'foo';`
-      },
-      {
-        code:
-        `import * as a from 'foo';
+  `import A from 'foo';
+        import a from 'bar';`,
+  `import a, * as b from 'foo';
+        import c from 'bar';`,
+  `import 'foo';
+        import a from 'bar';`,
+  `import B from 'foo.js';
+        import a from 'bar';`,
+  {
+    code:
+    `import a from 'foo';
+        import B from 'bar';`,
+    options: ['ignore-case']
+  },
+  {
+    code:
+    `import {a, b, c, d} from 'foo';`
+  },
+  {
+    code: `import {b, A, C, d} from 'foo';`,
+    options: ['ignore-member-sort']
+  },
+  {
+    code: `import {B, a, C, d} from 'foo';`,
+    options: ['ignore-member-sort']
+  },
+  {
+    code: `import {a, B, c, D} from 'foo';`,
+    options: ['ignore-case']
+  },
+  {
+    code:
+    `import a, * as b from 'foo';`
+  },
+  {
+    code:
+    `import * as a from 'foo';
 
         import b from 'bar';`
-      },
-      {
-        code:
-        `import * as bar from 'bar';
+  },
+  {
+    code:
+    `import * as bar from 'bar';
         import * as foo from 'foo';`
-      },
-      {
-        code:
-        `import 'foo';
+  },
+  {
+    code:
+    `import 'foo';
         import bar from 'bar';`,
-        rules: {
-          'sort-imports': [true,
-            'ignore-case']
-        }
-      },
-      {
-        code:
-        `import React, {Component} from 'react';`
-      }
-    ],
-    invalid: [
-      {
-        code:
-        `import a from 'foo';
-        import A from 'bar';`
-      },
-      {
-        code:
-        `import b from 'foo';
-        import a from 'bar';`
-      },
-      {
-        code:
-        `import {b, c} from 'foo';
-        import {a, d} from 'bar';`
-      },
-      {
-        code:
-        `import * as foo from 'foo'
-        import * as bar from 'bar';`
-      },
-      {
-        code:
-        `import a from 'foo';
-        import {b, c} from 'bar';`
-      },
-      {
-        code:
-        `import a from 'foo';
-        import * as b from 'bar';`
-      },
-      {
-        code:
-        `import a from 'foo';
-        import 'bar';`
-      },
-      {
-        code:
-        `import b from 'bar';
+    options: ['ignore-case']
+  },
+  `import React, {Component} from 'react';`
+]);
+
+ruleTester.addTestGroup('invalid', 'should fail ESLint invalid tests', [
+  {
+    code: `import a from 'foo';
+        import A from 'bar';`,
+    errors: expecting([{ message: formatString(ALPHA_ORDER_ERROR, 'A', 'a'), line: 1, startColumn: 8, endColumn: 28 }])
+  },
+  {
+    code: `import b from 'foo';
+        import a from 'bar';`,
+    errors: expecting([{ message: formatString(ALPHA_ORDER_ERROR, 'a', 'b'), line: 1, startColumn: 8, endColumn: 28 }])
+  },
+  {
+    code: `import {b, c} from 'foo';
+        import {a, d} from 'bar';`,
+    errors: expecting([{ message: formatString(ALPHA_ORDER_ERROR, 'a', 'b'), line: 1, startColumn: 8, endColumn: 33 }])
+  },
+  {
+    code: `import * as foo from 'foo'
+        import * as bar from 'bar';`,
+    errors: expecting([{ message: formatString(ALPHA_ORDER_ERROR, 'bar', 'foo'), line: 1, startColumn: 8, endColumn: 35 }])
+  },
+  {
+    code: `import a from 'foo';
+        import {b, c} from 'bar';`,
+    errors: expecting([{ message: formatString(TYPE_ORDER_ERROR, 'Multiple', 'Single'), line: 1, startColumn: 8, endColumn: 33 }])
+  },
+  {
+    code: `import a from 'foo';
+        import * as b from 'bar';`,
+    errors: expecting([{ message: formatString(TYPE_ORDER_ERROR, 'All', 'Single'), line: 1, startColumn: 8, endColumn: 33 }])
+  },
+  {
+    code: `import a from 'foo';
+        import 'bar';`,
+    errors: expecting([{ message: formatString(TYPE_ORDER_ERROR, 'None', 'Single'), line: 1, startColumn: 8, endColumn: 21 }])
+  },
+  {
+    code:
+    `import b from 'bar';
         import * as a from 'foo';`,
-        rules: {
-          'sort-imports': [
-            true,
-            { 'member-syntax-sort-order': ['all', 'single', 'multiple', 'none', 'alias'] }
-          ]
-        }
-      },
-      {
-        code: `import {b, a, d, c} from 'foo';`
-      },
-      {
-        code: `import {a, B, c, D} from 'foo';`
-      },
-      {
-        code: `import {zzzzz, /* comment */ aaaaa} from 'foo';`
-      },
-      {
-        code: `import {zzzzz /* comment */, aaaaa} from 'foo';`
-      },
-      {
-        code: `import {/* comment */ zzzzz, aaaaa} from 'foo';`
-      },
-      {
-        code: `import {zzzzz, aaaaa /* comment */} from 'foo';`
-      },
-      {
-        code: `
+    options: [{ 'member-syntax-sort-order': ['all', 'single', 'multiple', 'none', 'alias'] }],
+    errors: expecting([{ message: formatString(TYPE_ORDER_ERROR, 'All', 'Single'), line: 1, startColumn: 8, endColumn: 33 }])
+  },
+  {
+    code: `import {b, a, d, c} from 'foo';`,
+    errors: expecting([{ message: MEMBER_SORT_ERROR, line: 0, startColumn: 7, endColumn: 19 }])
+  },
+  {
+    code: `import {a, B, c, D} from 'foo';`,
+    errors: expecting([{ message: MEMBER_SORT_ERROR, line: 0, startColumn: 7, endColumn: 19 }])
+  },
+  {
+    code: `import {zzzzz, /* comment */ aaaaa} from 'foo';`,
+    errors: expecting([{ message: MEMBER_SORT_ERROR, line: 0, startColumn: 7, endColumn: 35 }])
+  },
+  {
+    code: `import {zzzzz /* comment */, aaaaa} from 'foo';`,
+    errors: expecting([{ message: MEMBER_SORT_ERROR, line: 0, startColumn: 7, endColumn: 35 }])
+  },
+  {
+    code: `import {/* comment */ zzzzz, aaaaa} from 'foo';`,
+    errors: expecting([{ message: MEMBER_SORT_ERROR, line: 0, startColumn: 7, endColumn: 35 }])
+  },
+  {
+    code: `import {zzzzz, aaaaa /* comment */} from 'foo';`,
+    errors: expecting([{ message: MEMBER_SORT_ERROR, line: 0, startColumn: 7, endColumn: 35 }])
+  },
+  {
+    code: `
               import {
                 boop,
                 foo,
@@ -203,35 +177,13 @@ const scripts = {
                 bar,
                 beep
               } from 'foo';
-            `
-      }
-    ]
+            `,
+    errors: [{
+      failure: MEMBER_SORT_ERROR,
+      startPosition: new Position(1, 21),
+      endPosition: new Position(8, 15)
+    }]
   }
-};
+]);
 
-describe(ruleName, function test() {
-  const defaultConfig = { rules: { 'sort-imports': true } };
-
-  it('should pass valid ESLint parity tests', function testVariables() {
-    makeTest(ruleName, scripts.eslintParityDefaults.valid, true, defaultConfig);
-  });
-
-  it('should fail invalid ESLint parity tests', function testVariables() {
-    makeTest(ruleName, scripts.eslintParityDefaults.invalid, false, defaultConfig);
-  });
-});
-
-function makeTest(rule: string, codeFragment: Array<{ code: string, rules?: {} }>, expected: boolean, defaultConfig?: { rules: {} }) {
-  if (!defaultConfig) {
-    defaultConfig = {
-      rules: {}
-    };
-
-    defaultConfig.rules[rule] = true;
-  }
-
-  codeFragment.forEach((code) => {
-    const res = testScript(rule, code.code, code.rules ? { rules: code.rules } : defaultConfig);
-    expect(res).to.equal(expected, code.code);
-  });
-}
+ruleTester.runTests();

--- a/src/test/rules/sortImportsRuleTests.ts
+++ b/src/test/rules/sortImportsRuleTests.ts
@@ -1,0 +1,27 @@
+import { RuleTester, Failure, Position, dedent } from './ruleTester';
+
+const ruleTester = new RuleTester('sort-imports');
+
+function expecting(errors: string[]]): Failure[] {
+  return errors.map((err) => {
+    let message = '';
+    return {
+      failure: message,
+      startPosition: new Position(err[0]),
+      endPosition: new Position()
+    };
+  });
+}
+
+ruleTester.addTestGroup('group-name', 'should ...', [
+  {
+    code: dedent`
+     // code goes here
+     `,
+    options: [],
+    errors: expecting([
+    ])
+  }
+]);
+
+ruleTester.runTests();


### PR DESCRIPTION
This is a new rule that enforces import sorting in the same way that ESLint does, rather than TSLint's ordered-imports rule that really only checks imported member sorts.