### PR TITLE
[fix] ter-prefer-arrow-callback broken test

### DIFF
--- a/src/rules/terPreferArrowCallbackRule.ts
+++ b/src/rules/terPreferArrowCallbackRule.ts
@@ -255,7 +255,10 @@ class RuleWalker extends Lint.RuleWalker {
           info.isRecursive = true;
         }
       } else if (
-        node.kind === ts.SyntaxKind.PropertyAccessExpression &&
+        (
+          node.kind === ts.SyntaxKind.PropertyAccessExpression ||
+          node.kind === ts.SyntaxKind.MetaProperty
+        ) &&
         checkMetaProperty(node as ts.PropertyAccessExpression, 'new', 'target')
       ) {
         info.hasMeta = true;


### PR DESCRIPTION
With the update to typescript 2.2 the tree structure changed and now we
have the `MetaProperty`. I’m still leaving the old format for backwards
compatibility with typescript < 2.2.