### PR TITLE
[fix] project requires tslint >= 4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "yargs": "^5.0.0"
   },
   "peerDependencies": {
-    "tslint": "^4.0.0"
+    "tslint": "^4.3.0"
   },
   "dependencies": {
     "doctrine": "^0.7.2"


### PR DESCRIPTION
Some of the rules now implement fixers which depend on the method
`createFix` which was introduced in
https://github.com/palantir/tslint/commit/e933f7d85b120041b64c5ce7edcfbb
df80e57926.