### PR TITLE
[test] Test helper deprecation

### DIFF
--- a/src/rules/validJsdocRule.ts
+++ b/src/rules/validJsdocRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     missingReturnDescription: 'missing JSDoc return description',
     prefer: (name: string) => `use @${name} instead`,
     missingReturn: (param: string) => `missing JSDoc @${param || 'returns'} for function`,
-    wrongParam: (expected: string, actual: string) => `expected JSDoc for '${expected}'' but found '${actual}'`,
+    wrongParam: (expected: string, actual: string) => `expected JSDoc for '${expected}' but found '${actual}'`,
     missingParam: (name: string) => `missing JSDoc for parameter '${name}'`,
     wrongDescription: 'JSDoc description does not satisfy the regex pattern',
     invalidRegexDescription: (error: string) => `configured matchDescription is an invalid RegExp. Error: ${error}`

--- a/src/test/rules/blockSpacingRuleTests.ts
+++ b/src/test/rules/blockSpacingRuleTests.ts
@@ -31,20 +31,30 @@ ruleTester.addTestGroup('always-invalid', 'fails with "always" and missing space
   { code: `switch (myVar) {case 1: return true;}`, errors: expecting([true]) }
 ]);
 
-ruleTester.addTestGroup('never-valid', 'passes with "never" and missing spaces inside brackets', [
-  { code: `function foo() {return true;}`, options: ['never'] },
-  { code: `if (foo) {bar = 0;}`, options: ['never'] },
-  { code: `switch (myVar) {case 1: return true;}`, options: ['never'] },
-  { code: `function foo() {}`, options: ['never'] },
-  { code: `function foo() { }`, options: ['never'] }
-]);
+ruleTester.addTestGroupWithConfig(
+  'never-valid',
+  'passes with "never" and missing spaces inside brackets',
+  ['never'],
+  [
+    `function foo() {return true;}`,
+    `if (foo) {bar = 0;}`,
+    `switch (myVar) {case 1: return true;}`,
+    `function foo() {}`,
+    `function foo() { }`
+  ]
+);
 
-ruleTester.addTestGroup('never-invalid', 'fails with "never" and there are spaces inside brackets', [
-  { code: `function foo() { return true; }`, options: ['never'], errors: expecting([false]) },
-  { code: `if (foo) { bar = 0;}`, options: ['never'], errors: expecting([false]) },
-  { code: `switch (myVar) { case 1: return true;}`, options: ['never'], errors: expecting([false]) },
-  { code: `switch (myVar) {case 1: return true; }`, options: ['never'], errors: expecting([false]) },
-  { code: `switch (myVar) { case 1: return true; }`, options: ['never'], errors: expecting([false]) }
-]);
+ruleTester.addTestGroupWithConfig(
+  'never-invalid',
+  'fails with "never" and there are spaces inside brackets',
+  ['never'],
+  [
+    { code: `function foo() { return true; }`, errors: expecting([false]) },
+    { code: `if (foo) { bar = 0;}`, errors: expecting([false]) },
+    { code: `switch (myVar) { case 1: return true;}`, errors: expecting([false]) },
+    { code: `switch (myVar) {case 1: return true; }`, errors: expecting([false]) },
+    { code: `switch (myVar) { case 1: return true; }`, errors: expecting([false]) }
+  ]
+);
 
 ruleTester.runTests();

--- a/src/test/rules/blockSpacingRuleTests.ts
+++ b/src/test/rules/blockSpacingRuleTests.ts
@@ -1,59 +1,50 @@
-/// <reference path='../../../typings/mocha/mocha.d.ts' />
-import { makeTest } from './helper';
+import { RuleTester, Failure, Position } from './ruleTester';
 
-const rule = 'block-spacing';
-const scripts = {
-  always: {
-    valid: [
-      `function foo() { return true; }`,
-      `if (foo) { bar = 0; }`,
-      `switch (myVar) { case 1: return true; }`,
-      `function foo() {}`,
-      `function foo() { }`
-    ],
-    invalid: [
-      `function foo() {return true;}`,
-      `if (foo) { bar = 0;}`,
-      `switch (myVar) { case 1: return true;}`,
-      `switch (myVar) {case 1: return true; }`,
-      `switch (myVar) {case 1: return true;}`
-    ]
-  },
-  never: {
-    valid: [
-      `function foo() {return true;}`,
-      `if (foo) {bar = 0;}`,
-      `switch (myVar) {case 1: return true;}`,
-      `function foo() {}`,
-      `function foo() { }`
-    ],
-    invalid: [
-      `function foo() { return true; }`,
-      `if (foo) { bar = 0;}`,
-      `switch (myVar) { case 1: return true;}`,
-      `switch (myVar) {case 1: return true; }`,
-      `switch (myVar) { case 1: return true; }`
-    ]
-  }
-};
+const ruleTester = new RuleTester('block-spacing');
 
-describe(rule, function test() {
-  const alwaysConfig = { rules: { 'block-spacing': [true, 'always'] } };
-  const neverConfig = { rules: { 'block-spacing': [true, 'never'] } };
-
-  it('should pass when "always" and there are spaces inside brackets', function testVariables() {
-    makeTest(rule, scripts.always.valid, true, alwaysConfig);
+// Only checking if there should be a space or not
+function expecting(errors: boolean[]): Failure[] {
+  // true means there should be a space
+  return errors.map((err) => {
+    const status = err ? 'Requires a space' : 'Unexpected space(s)';
+    return {
+      failure: status,
+      startPosition: new Position(),
+      endPosition: new Position()
+    };
   });
+}
 
-  it('should fail when "always" and there are not spaces inside brackets', function testVariables() {
-    makeTest(rule, scripts.always.invalid, false, alwaysConfig);
-  });
+ruleTester.addTestGroup('always-valid', 'passes with "always" and there are spaces inside brackets', [
+  `function foo() { return true; }`,
+  `if (foo) { bar = 0; }`,
+  `switch (myVar) { case 1: return true; }`,
+  `function foo() {}`,
+  `function foo() { }`
+]);
 
-  it('should pass when "never" and there are not spaces inside brackets', function testVariables() {
-    makeTest(rule, scripts.never.valid, true, neverConfig);
-  });
+ruleTester.addTestGroup('always-invalid', 'fails with "always" and missing spaces inside brackets', [
+  { code: `function foo() {return true;}`, errors: expecting([true]) },
+  { code: `if (foo) { bar = 0;}`, errors: expecting([true]) },
+  { code: `switch (myVar) { case 1: return true;}`, errors: expecting([true]) },
+  { code: `switch (myVar) {case 1: return true; }`, errors: expecting([true]) },
+  { code: `switch (myVar) {case 1: return true;}`, errors: expecting([true]) }
+]);
 
-  it('should fail when "never" and there are spaces inside brackets', function testVariables() {
-    makeTest(rule, scripts.never.invalid, false, neverConfig);
-  });
-});
+ruleTester.addTestGroup('never-valid', 'passes with "never" and missing spaces inside brackets', [
+  { code: `function foo() {return true;}`, options: ['never'] },
+  { code: `if (foo) {bar = 0;}`, options: ['never'] },
+  { code: `switch (myVar) {case 1: return true;}`, options: ['never'] },
+  { code: `function foo() {}`, options: ['never'] },
+  { code: `function foo() { }`, options: ['never'] }
+]);
+
+ruleTester.addTestGroup('never-invalid', 'fails with "never" and there are spaces inside brackets', [
+  { code: `function foo() { return true; }`, options: ['never'], errors: expecting([false]) },
+  { code: `if (foo) { bar = 0;}`, options: ['never'], errors: expecting([false]) },
+  { code: `switch (myVar) { case 1: return true;}`, options: ['never'], errors: expecting([false]) },
+  { code: `switch (myVar) {case 1: return true; }`, options: ['never'], errors: expecting([false]) },
+  { code: `switch (myVar) { case 1: return true; }`, options: ['never'], errors: expecting([false]) }
+]);
+
+ruleTester.runTests();

--- a/src/test/rules/braceStyleRuleTests.ts
+++ b/src/test/rules/braceStyleRuleTests.ts
@@ -1,76 +1,109 @@
-/// <reference path='../../../typings/mocha/mocha.d.ts' />
-import { makeTest } from './helper';
+import { RuleTester, Failure, Position, dedent } from './ruleTester';
 
-const rule = 'brace-style';
-const scripts = {
-  onetbs: {
-    valid: [
-      `function foo() {
-        return true;
-      }`,
+const ruleTester = new RuleTester('brace-style');
 
-      `if (foo) {
-        bar();
-      }`,
+const fail = {
+  open: 'Opening curly brace does not appear on the same line as controlling statement.',
+  openAllman: 'Opening curly brace appears on the same line as controlling statement.',
+  body: 'Statement inside of curly braces should be on next line.',
+  close: 'Closing curly brace does not appear on the same line as the subsequent block.',
+  closeSingle: 'Closing curly brace should be on the same line as opening curly brace or on the line after the previous block.',
+  closeStroustrupAllman: 'Closing curly brace appears on the same line as the subsequent block.'
+};
 
-      `if (foo) {
-        bar();
-      } else {
-        baz();
-      }`,
+// Only checking for messages for now. We should revisit these tests specifying the line numbers
+// and make sure that we are getting the correct errors.
+// Note: so far there are no test that check for `fail.close` and `fail.closeStroustrupAllman`.
+function expecting(errors: string[]): Failure[] {
+  return errors.map((err) => {
+    return {
+      failure: err,
+      startPosition: new Position(),
+      endPosition: new Position()
+    };
+  });
+}
 
-      `try {
-        somethingRisky();
-      } catch(e) {
-        handleError();
-      }`,
+ruleTester.addTestGroupWithConfig('onetbs-valid', 'should pass when "1tbs"', ['1tbs'], [
+  dedent`
+    function foo() {
+      return true;
+    }`,
+  dedent`
+    if (foo) {
+      bar();
+    }`,
+  dedent`
+    if (foo) {
+      bar();
+    } else {
+      baz();
+    }`,
+  dedent`
+    try {
+      somethingRisky();
+    } catch(e) {
+      handleError();
+    }`,
+  dedent`
+    try {
+      somethingRisky();
+    } catch(e) {
+      handleError();
+    } finally() {
+      doSomething();
+    }`,
+  dedent`
+    try {
+      somethingRisky();
+    } finally() {
+      doSomething();
+    } catch(e) {
+      handleError();
+    }`,
+  dedent`
+    try {
+      somethingRisky();
+    } finally() {
+      doSomething();
+    }`,
+  // when there are no braces, there are no problems
+  dedent`
+    if (foo) bar();
+    else if (baz) boom();`
+]);
 
-      `try {
-        somethingRisky();
-      } catch(e) {
-        handleError();
-      } finally() {
-        doSomething();
-      }`,
-
-      `try {
-        somethingRisky();
-      } finally() {
-        doSomething();
-      } catch(e) {
-        handleError();
-      }`,
-
-      `try {
-        somethingRisky();
-      } finally() {
-        doSomething();
-      }`,
-
-      // when there are no braces, there are no problems
-      `if (foo) bar();
-      else if (baz) boom();`
-    ],
-    invalid: [
-      `function foo()
+ruleTester.addTestGroupWithConfig('onetbs-invalid', 'should fail when "1tbs"', ['1tbs'], [
+  {
+    code: dedent`
+      function foo()
       {
         return true;
       }`,
-
-      `if (foo)
+    errors: expecting([fail.open])
+  },
+  {
+    code: dedent`
+      if (foo)
       {
         bar();
       }`,
-
-      `try
+    errors: expecting([fail.open])
+  },
+  {
+    code: dedent`
+      try
       {
         somethingRisky();
       } catch(e)
       {
         handleError();
       }`,
-
-      `try
+    errors: expecting([fail.open])
+  },
+  {
+    code: dedent`
+      try
       {
         somethingRisky();
       } catch(e)
@@ -81,93 +114,116 @@ const scripts = {
       {
         doSomething();
       }`,
-
-      `try
+    errors: expecting([fail.open])
+  },
+  {
+    code: dedent`
+      try
       {
         somethingRisky();
       } finally(e)
       {
         doSomething();
       }`,
-
-      `if (foo) {
-        bar();
-      }
-      else {
-        baz();
-      }`,
-
-      `if (foo) {
-        bar();
-      } else { baz(); }`
-    ]
+    errors: expecting([fail.open])
   },
-  stroustrup: {
-    valid: [
-      `function foo() {
-        return true;
-      }`,
-
-      `if (foo) {
-        bar();
-      }`,
-
-      `if (foo) {
+  {
+    code: dedent`
+      if (foo) {
         bar();
       }
       else {
         baz();
       }`,
+    errors: expecting([fail.open])
+  },
+  {
+    code: dedent`
+      if (foo) {
+        bar();
+      } else { baz(); }`,
+    errors: expecting([fail.body, fail.closeSingle])
+  }
+]);
 
-      `try {
-        somethingRisky();
-      }
-      catch(e) {
-        handleError();
-      }`,
+ruleTester.addTestGroupWithConfig('stroustrup-valid', 'should pass when "stroustrup"', ['stroustrup'], [
+  dedent`
+    function foo() {
+      return true;
+    }`,
+  dedent`
+    if (foo) {
+      bar();
+    }`,
+  dedent`
+    if (foo) {
+      bar();
+    }
+    else {
+      baz();
+    }`,
+  dedent`
+    try {
+      somethingRisky();
+    }
+    catch(e) {
+      handleError();
+    }`,
+  dedent`
+    try {
+      somethingRisky();
+    }
+    catch(e) {
+      handleError();
+    }
+    finally() {
+      doSomething();
+    }
+    `,
+  dedent`
+    try {
+      somethingRisky();
+    }
+    finally {
+      doSomething();
+    }`,
+  // when there are no braces, there are no problems
+  dedent`
+    if (foo) bar();
+    else if (baz) boom();`
+]);
 
-      `try {
-        somethingRisky();
-      }
-      catch(e) {
-        handleError();
-      }
-      finally() {
-        doSomething();
-      }
-      `,
-
-      `try {
-        somethingRisky();
-      }
-      finally {
-        doSomething();
-      }`,
-
-      // when there are no braces, there are no problems
-      `if (foo) bar();
-      else if (baz) boom();`
-    ],
-    invalid: [
-      `function foo()
+ruleTester.addTestGroupWithConfig('stroustrup-invalid', 'should fail when "stroustrup"', ['stroustrup'], [
+  {
+    code: dedent`
+      function foo()
       {
         return true;
       }`,
-
-      `if (foo)
+    errors: expecting([fail.open])
+  },
+  {
+    code: dedent`
+      if (foo)
       {
         bar();
       }`,
-
-      `try
+    errors: expecting([fail.open])
+  },
+  {
+    code: dedent`
+      try
       {
         somethingRisky();
       } catch(e)
       {
         handleError();
       }`,
-
-      `try
+    errors: expecting([fail.open, fail.openAllman])
+  },
+  {
+    code: dedent`
+      try
       {
         somethingRisky();
       } catch(e)
@@ -176,101 +232,117 @@ const scripts = {
       } finally()
       {
         doSomething();
-      }
-      `,
-
-      `try
+      }`,
+    errors: expecting([fail.open, fail.openAllman])
+  },
+  {
+    code: dedent`
+      try
       {
         somethingRisky();
       } finally()
       {
         doSomething();
-      }
-      `,
-
-      `if (foo) {
+      }`,
+    errors: expecting([fail.open, fail.openAllman])
+  },
+  {
+    code: dedent`
+      if (foo) {
         bar();
       } else {
         baz();
-      }`
-    ]
+      }`,
+    errors: expecting([fail.openAllman])
+  }
+]);
+
+ruleTester.addTestGroupWithConfig('allman-valid', 'should pass when "allman"', ['allman'], [
+  dedent`
+    function foo()
+    {
+      return true;
+    }`,
+  dedent`
+    if (foo)
+    {
+      bar();
+    }`,
+  dedent`
+    if (foo)
+    {
+      bar();
+    }
+    else
+    {
+      baz();
+    }`,
+  dedent`
+    try
+    {
+      somethingRisky();
+    }
+    catch(e)
+    {
+      handleError();
+    }`,
+  dedent`
+    try
+    {
+      somethingRisky();
+    }
+    catch(e)
+    {
+      handleError();
+    }
+    finally()
+    {
+      doSomething();
+    }`,
+  dedent`
+    try
+    {
+      somethingRisky();
+    }
+    finally()
+    {
+      doSomething();
+    }`,
+  // when there are no braces, there are no problems
+  dedent`
+    if (foo) bar();
+    else if (baz) boom();`
+]);
+
+ruleTester.addTestGroupWithConfig('allman-invalid', 'should fail when "allman"', ['allman'], [
+  {
+    code: dedent`
+      function foo() {
+        return true;
+      }`,
+    errors: expecting([fail.openAllman])
   },
-  allman: {
-    valid: [
-      `function foo()
-      {
-        return true;
-      }`,
-
-      `if (foo)
-      {
-        bar();
-      }`,
-
-      `if (foo)
-      {
-        bar();
-      }
-      else
-      {
-        baz();
-      }`,
-
-      `try
-      {
-        somethingRisky();
-      }
-      catch(e)
-      {
-        handleError();
-      }`,
-
-      `try
-      {
-        somethingRisky();
-      }
-      catch(e)
-      {
-        handleError();
-      }
-      finally()
-      {
-        doSomething();
-      }
-      `,
-
-      `try
-      {
-        somethingRisky();
-      }
-      finally()
-      {
-        doSomething();
-      }
-      `,
-
-      // when there are no braces, there are no problems
-      `if (foo) bar();
-      else if (baz) boom();`
-    ],
-    invalid: [
-      `function foo() {
-        return true;
-      }`,
-
-      `if (foo)
+  {
+    code: dedent`
+      if (foo)
       {
         bar(); }`,
-
-      `try
+    errors: expecting([fail.closeSingle])
+  },
+  {
+    code: dedent`
+      try
       {
         somethingRisky();
       } catch(e)
       {
         handleError();
       }`,
-
-      `try {
+    errors: expecting([fail.openAllman])
+  },
+  {
+    code: dedent`
+      try {
         somethingRisky();
       } catch(e)
       {
@@ -278,201 +350,362 @@ const scripts = {
       } finally()
       {
         doSomething();
-      }
-      `,
-
-      `try {
+      }`,
+    errors: expecting([fail.openAllman])
+  },
+  {
+    code: dedent`
+      try {
         somethingRisky();
       } finally()
       {
         doSomething();
-      }
-      `,
-
-      `if (foo) {
+      }`,
+    errors: expecting([fail.openAllman])
+  },
+  {
+    code: dedent`
+      if (foo) {
         bar();
       } else {
         baz();
-      }`
-    ]
-  },
-  allowSingleLine: {
-    onetbs: {
-      valid: [
-        `function nop() { return; }`,
+      }`,
+    errors: expecting([fail.openAllman])
+  }
+]);
 
-        `if (foo) { bar(); }`,
+ruleTester.addTestGroupWithConfig(
+  'allowSingleLine-onetbs',
+  'should pass when "1tbs" and "allowSingleLine" is true',
+  ['1tbs', { allowSingleLine: true }],
+  [
+    `function nop() { return; }`,
+    `if (foo) { bar(); }`,
+    `if (foo) { bar(); } else { baz(); }`,
+    `try { somethingRisky(); } catch(e) { handleError(); }`,
+    `try { somethingRisky(); } catch(e) { handleError(); } finally() { doSomething(); }`,
+    `try { somethingRisky(); } finally(e) { doSomething(); }`,
+    dedent`
+      if (foo) {
+        bar();
+      } else { baz(); }`,
+    dedent`
+      try {
+        foo();
+      } catch(e) { bar(); }`,
+    dedent`
+      try {
+        foo();
+      } catch(e) { bar(); }
+      } finally() { doSomething(); }`,
+    dedent`
+      try {
+        foo();
+      } finally() { doSomething(); }`
+  ]
+);
 
-        `if (foo) { bar(); } else { baz(); }`,
-
-        `try { somethingRisky(); } catch(e) { handleError(); }`,
-
-        `try { somethingRisky(); } catch(e) { handleError(); } finally() { doSomething(); }`,
-
-        `try { somethingRisky(); } finally(e) { doSomething(); }`,
-
-        `if (foo) {
+ruleTester.addTestGroupWithConfig(
+  'allowSingleLine-onetbs-invalid',
+  'should fail when "1tbs" and "allowSingleLine" is false',
+  ['1tbs', { allowSingleLine: false }],
+  [
+    {
+      code: `function nop() { return; }`,
+      errors: expecting([fail.body, fail.closeSingle])
+    },
+    {
+      code: `if (foo) { bar(); }`,
+      errors: expecting([fail.body, fail.closeSingle])
+    },
+    {
+      code: `if (foo) { bar(); } else { baz(); }`,
+      errors: expecting([fail.body, fail.closeSingle])
+    },
+    {
+      code: `try { somethingRisky(); } catch(e) { handleError(); }`,
+      errors: expecting([fail.body, fail.closeSingle])
+    },
+    {
+      code: `try { somethingRisky(); } catch(e) { handleError(); } finally() { doSomething(); }`,
+      errors: expecting([fail.body, fail.closeSingle])
+    },
+    {
+      code: `try { somethingRisky(); } finally(e) { doSomething(); }`,
+      errors: expecting([fail.body, fail.closeSingle])
+    },
+    {
+      code: dedent`
+        if (foo) {
           bar();
         } else { baz(); }`,
-
-        `try {
+      errors: expecting([fail.body, fail.closeSingle])
+    },
+    {
+      code: dedent`
+        try {
           foo();
         } catch(e) { bar(); }`,
-
-        `try {
+      errors: expecting([fail.body, fail.closeSingle])
+    },
+    {
+      code: dedent`
+        try {
           foo();
         } catch(e) { bar(); }
         } finally() { doSomething(); }`,
-
-        `try {
-          foo();
-        } finally() { doSomething(); }`
-      ]
+      errors: expecting([fail.body, fail.closeSingle])
     },
-    stroustrup: {
-      valid: [
-        `function nop() { return; }`,
+    {
+      code: dedent`
+        try {
+          foo();
+        } finally() { doSomething(); }`,
+      errors: expecting([fail.body, fail.closeSingle])
+    }
+  ]
+);
 
-        `if (foo) { bar(); }`,
+ruleTester.addTestGroupWithConfig(
+  'allowSingleLine-stroustrup',
+  'should pass when "stroustrup" and "allowSingleLine" is true',
+  ['stroustrup', { allowSingleLine: true }],
+  [
+    `function nop() { return; }`,
+    `if (foo) { bar(); }`,
+    dedent`
+      if (foo) { bar(); }
+      else { baz(); }`,
+    dedent`
+      try { somethingRisky(); }
+      catch(e) { handleError(); }`,
+    dedent`
+      try { somethingRisky(); }
+      catch(e) { handleError(); }
+      finally() { doSomething(); }`,
+    dedent`
+      try { somethingRisky(); }
+      finally() { doSomething(); }`,
+    dedent`
+      if (foo) {
+        bar();
+      }
+      else { baz(); }`,
+    dedent`
+      try {
+        foo();
+      }
+      catch(e) { bar(); }`,
+    dedent`
+      try {
+        foo();
+      }
+      catch(e) { bar(); }
+      finally() { doSomething(); }`,
+    dedent`
+      try {
+        foo();
+      }
+      finally() { doSomething(); }`
+  ]
+);
 
-        `if (foo) { bar(); }
+ruleTester.addTestGroupWithConfig(
+  'allowSingleLine-stroustrup-invalid',
+  'should fail when "stroustrup" and "allowSingleLine" is false',
+  ['stroustrup', { allowSingleLine: false }],
+  [
+    {
+      code: `function nop() { return; }`,
+      errors: expecting([fail.body, fail.closeSingle])
+    },
+    {
+      code: `if (foo) { bar(); }`,
+      errors: expecting([fail.body, fail.closeSingle])
+    },
+    {
+      code: dedent`
+        if (foo) { bar(); }
         else { baz(); }`,
-
-        `try { somethingRisky(); }
+      errors: expecting([fail.body, fail.closeSingle])
+    },
+    {
+      code: dedent`
+        try { somethingRisky(); }
         catch(e) { handleError(); }`,
-
-        `try { somethingRisky(); }
+      errors: expecting([fail.body, fail.closeSingle])
+    },
+    {
+      code: dedent`
+        try { somethingRisky(); }
         catch(e) { handleError(); }
         finally() { doSomething(); }`,
-
-        `try { somethingRisky(); }
+      errors: expecting([fail.body, fail.closeSingle])
+    },
+    {
+      code: dedent`
+        try { somethingRisky(); }
         finally() { doSomething(); }`,
-
-        `if (foo) {
+      errors: expecting([fail.body, fail.closeSingle])
+    },
+    {
+      code: dedent`
+        if (foo) {
           bar();
         }
         else { baz(); }`,
-
-        `try {
+      errors: expecting([fail.body, fail.closeSingle])
+    },
+    {
+      code: dedent`
+        try {
           foo();
         }
         catch(e) { bar(); }`,
-
-        `try {
+      errors: expecting([fail.body, fail.closeSingle])
+    },
+    {
+      code: dedent`
+        try {
           foo();
         }
         catch(e) { bar(); }
         finally() { doSomething(); }`,
-
-        `try {
+      errors: expecting([fail.body, fail.closeSingle])
+    },
+    {
+      code: dedent`
+        try {
           foo();
         }
-        finally() { doSomething(); }`
-      ]
+        finally() { doSomething(); }`,
+      errors: expecting([fail.body, fail.closeSingle])
+    }
+  ]
+);
+
+ruleTester.addTestGroupWithConfig(
+  'allowSingleLine-allman',
+  'should pass when "allman" and "allowSingleLine" is true',
+  ['allman', { allowSingleLine: true }],
+  [
+    `function nop() { return; }`,
+    `if (foo) { bar(); }`,
+    dedent`
+      if (foo) { bar(); }
+      else { baz(); }`,
+    dedent`
+      try { somethingRisky(); }
+      catch(e) { handleError(); }`,
+    dedent`
+      try { somethingRisky(); }
+      catch(e) { handleError(); },
+      finally() { doSomething(); }`,
+    dedent`
+      try { somethingRisky(); }
+      finally(e) { doSomething(); }`,
+    dedent`
+      if (foo)
+      {
+        bar();
+      } else { baz(); }`,
+    dedent`
+      try
+      {
+        foo();
+      }
+      catch(e) { bar(); }`,
+    dedent`
+      try
+      {
+        foo();
+      }
+      catch(e) { bar(); }
+      finally() { doSomething(); }`,
+    dedent`
+      try
+      {
+        foo();
+      }
+      finally() { doSomething(); }`
+  ]
+);
+
+ruleTester.addTestGroupWithConfig(
+  'allowSingleLine-allman-invalid',
+  'should fail when "allman" and "allowSingleLine" is false',
+  ['allman', { allowSingleLine: false }],
+  [
+    {
+      code: `function nop() { return; }`,
+      errors: expecting([fail.body, fail.closeSingle, fail.openAllman])
     },
-    allman: {
-      valid: [
-        `function nop() { return; }`,
-
-        `if (foo) { bar(); }`,
-
-        `if (foo) { bar(); }
+    {
+      code: `if (foo) { bar(); }`,
+      errors: expecting([fail.body, fail.closeSingle, fail.openAllman])
+    },
+    {
+      code: dedent`
+        if (foo) { bar(); }
         else { baz(); }`,
-
-        `try { somethingRisky(); }
+      errors: expecting([fail.body, fail.closeSingle, fail.openAllman])
+    },
+    {
+      code: dedent`
+        try { somethingRisky(); }
         catch(e) { handleError(); }`,
-
-        `try { somethingRisky(); }
+      errors: expecting([fail.body, fail.closeSingle, fail.openAllman])
+    },
+    {
+      code: dedent`
+        try { somethingRisky(); }
         catch(e) { handleError(); },
         finally() { doSomething(); }`,
-
-        `try { somethingRisky(); }
+      errors: expecting([fail.body, fail.closeSingle, fail.openAllman])
+    },
+    {
+      code: dedent`
+        try { somethingRisky(); }
         finally(e) { doSomething(); }`,
-
-        `if (foo)
+      errors: expecting([fail.body, fail.closeSingle, fail.openAllman])
+    },
+    {
+      code: dedent`
+        if (foo)
         {
           bar();
         } else { baz(); }`,
-
-        `try
+      errors: expecting([fail.body, fail.closeSingle, fail.openAllman])
+    },
+    {
+      code: dedent`
+        try
         {
           foo();
         }
         catch(e) { bar(); }`,
-
-        `try
+      errors: expecting([fail.body, fail.closeSingle, fail.openAllman])
+    },
+    {
+      code: dedent`
+        try
         {
           foo();
         }
         catch(e) { bar(); }
         finally() { doSomething(); }`,
-
-        `try
+      errors: expecting([fail.body, fail.closeSingle, fail.openAllman])
+    },
+    {
+      code: dedent`
+        try
         {
           foo();
         }
-        finally() { doSomething(); }`
-      ]
+        finally() { doSomething(); }`,
+      errors: expecting([fail.body, fail.closeSingle, fail.openAllman])
     }
-  }
-};
+  ]
+);
 
-describe(rule, function test() {
-  const onetbsConfig = { rules: { 'brace-style': [true, '1tbs'] } };
-  const stroustrupConfig = { rules: { 'brace-style': [true, 'stroustrup'] } };
-  const allmanConfig = { rules: { 'brace-style': [true, 'allman'] } };
-  const onetbsConfigWithException = { rules: { 'brace-style': [true, '1tbs', { allowSingleLine: true }] } };
-  const stroustrupConfigWithException = { rules: { 'brace-style': [true, 'stroustrup', { allowSingleLine: true }] } };
-  const allmanConfigWithException = { rules: { 'brace-style': [true, 'allman', { allowSingleLine: true }] } };
-
-  it('should pass when "1tbs"', function testVariables() {
-    makeTest(rule, scripts.onetbs.valid, true, onetbsConfig);
-  });
-
-  it('should fail when "1tbs"', function testVariables() {
-    makeTest(rule, scripts.onetbs.invalid, false, onetbsConfig);
-  });
-
-  it('should pass when "stroustrup"', function testVariables() {
-    makeTest(rule, scripts.stroustrup.valid, true, stroustrupConfig);
-  });
-
-  it('should fail when "stroustrup"', function testVariables() {
-    makeTest(rule, scripts.stroustrup.invalid, false, stroustrupConfig);
-  });
-
-  it('should pass when "allman"', function testVariables() {
-    makeTest(rule, scripts.allman.valid, true, allmanConfig);
-  });
-
-  it('should fail when "allman"', function testVariables() {
-    makeTest(rule, scripts.allman.invalid, false, allmanConfig);
-  });
-
-  it('should pass when "1tbs" and "allowSingleLine" is true', function testVariables() {
-    makeTest(rule, scripts.allowSingleLine.onetbs.valid, true, onetbsConfigWithException);
-  });
-
-  it('should pass when "stroustrup" and "allowSingleLine" is true', function testVariables() {
-    makeTest(rule, scripts.allowSingleLine.stroustrup.valid, true, stroustrupConfigWithException);
-  });
-
-  it('should pass when "allman" and "allowSingleLine" is true', function testVariables() {
-    makeTest(rule, scripts.allowSingleLine.allman.valid, true, allmanConfigWithException);
-  });
-
-  // all scripts in the "allowSingleLine" object should *only* pass if
-  // allowSingleLine === true, so let's check to make sure they
-  // fail if allowSingleLine === false
-  it('should fail when "1tbs"', function testVariables() {
-    makeTest(rule, scripts.allowSingleLine.onetbs.valid, false, onetbsConfig);
-  });
-
-  it('should fail when "stroustrup"', function testVariables() {
-    makeTest(rule, scripts.allowSingleLine.stroustrup.valid, false, stroustrupConfig);
-  });
-
-  it('should fail when "allman"', function testVariables() {
-    makeTest(rule, scripts.allowSingleLine.allman.valid, false, allmanConfig);
-  });
-});
+ruleTester.runTests();

--- a/src/test/rules/helper.ts
+++ b/src/test/rules/helper.ts
@@ -10,7 +10,7 @@ const options: Lint.ILinterOptions = {
 };
 
 /**
- * @deprecated
+ * @deprecated Use ruleTester
  */
 export function testScript(rule: string, scriptText: string, config: Object): boolean {
   const linter = new Lint.Linter(options);
@@ -22,7 +22,7 @@ export function testScript(rule: string, scriptText: string, config: Object): bo
 }
 
 /**
- * @deprecated
+ * @deprecated Use ruleTester
  */
 export function makeTest(rule: string, scripts: Array<string>, expected: boolean, config?: { rules: {} }) {
   if (!config) {

--- a/src/test/rules/helper.ts
+++ b/src/test/rules/helper.ts
@@ -9,6 +9,9 @@ const options: Lint.ILinterOptions = {
   rulesDirectory: 'dist/rules/'
 };
 
+/**
+ * @deprecated
+ */
 export function testScript(rule: string, scriptText: string, config: Object): boolean {
   const linter = new Lint.Linter(options);
   linter.lint(`${rule}.ts`, scriptText, config);
@@ -18,14 +21,9 @@ export function testScript(rule: string, scriptText: string, config: Object): bo
   return failures.length === 0;
 }
 
-export function fix(rule: string, scriptText: string, config: Object): string {
-  const linter = new Lint.Linter(options);
-  linter.lint(`${rule}.ts`, scriptText, config);
-
-  const fixes = linter.getResult().failures.filter(f => f.hasFix()).map(f => f.getFix());
-  return Lint.Fix.applyAll(scriptText, fixes);
-}
-
+/**
+ * @deprecated
+ */
 export function makeTest(rule: string, scripts: Array<string>, expected: boolean, config?: { rules: {} }) {
   if (!config) {
     config = {
@@ -38,20 +36,5 @@ export function makeTest(rule: string, scripts: Array<string>, expected: boolean
   scripts.forEach((code) => {
     const res = testScript(rule, code, config);
     expect(res).to.equal(expected, code);
-  });
-}
-
-export function makeFixTest(rule: string, inputs: Array<string>, outputs: Array<string>, config?: { rules: {} }) {
-  if (!config) {
-    config = {
-      rules: {}
-    };
-
-    config.rules[rule] = true;
-  }
-
-  inputs.forEach((code, index) => {
-    const res = fix(rule, code, config);
-    expect(res).to.equal(outputs[index], code);
   });
 }

--- a/src/test/rules/noRegexSpacesRuleTests.ts
+++ b/src/test/rules/noRegexSpacesRuleTests.ts
@@ -19,8 +19,8 @@ ruleTester.addTestGroup('valid', 'should pass when not using multiple spaces in 
 ]);
 
 ruleTester.addTestGroup('invalid', 'should fail when using multiple spaces in regular expressions', [
-  { code: 'var foo = /bar    baz/;', errors: expecting([[0, 10, 4]])},
-  { code: 'var foo = /bar      baz/;', errors: expecting([[0, 10, 6]])}
+  { code: 'var foo = /bar    baz/;', errors: expecting([[0, 10, 4]]) },
+  { code: 'var foo = /bar      baz/;', errors: expecting([[0, 10, 6]]) }
 ]);
 
 ruleTester.runTests();

--- a/src/test/rules/noRegexSpacesRuleTests.ts
+++ b/src/test/rules/noRegexSpacesRuleTests.ts
@@ -1,23 +1,26 @@
-/// <reference path='../../../typings/mocha/mocha.d.ts' />
-import { makeTest } from './helper';
+import { RuleTester, Failure, Position } from './ruleTester';
 
-const rule = 'no-regex-spaces';
-const scripts = {
-  valid: [
-    'var foo = /bar {3}baz/;',
-    'var foo = /bar\t\t\tbaz/;'
-  ],
-  invalid: [
-    'var foo = /bar    baz/;'
-  ]
-};
+const ruleTester = new RuleTester('no-regex-spaces');
 
-describe(rule, function test() {
-  it('should pass when not using multiple spaces in regular expressions', function testValid() {
-    makeTest(rule, scripts.valid, true);
+function expecting(errors: [number, number, number][]): Failure[] {
+  // [line, column]
+  return errors.map((err) => {
+    return {
+      failure: `spaces are hard to count - use {${err[2]}}`,
+      startPosition: new Position(err[0], err[1]),
+      endPosition: new Position()
+    };
   });
+}
 
-  it('should fail when using multiple spaces in regular expressions', function testInvalid() {
-    makeTest(rule, scripts.invalid, false);
-  });
-});
+ruleTester.addTestGroup('valid', 'should pass when not using multiple spaces in regular expressions', [
+  'var foo = /bar {3}baz/;',
+  'var foo = /bar\t\t\tbaz/;'
+]);
+
+ruleTester.addTestGroup('invalid', 'should fail when using multiple spaces in regular expressions', [
+  { code: 'var foo = /bar    baz/;', errors: expecting([[0, 10, 4]])},
+  { code: 'var foo = /bar      baz/;', errors: expecting([[0, 10, 6]])}
+]);
+
+ruleTester.runTests();

--- a/src/test/rules/noSparseArraysRuleTests.ts
+++ b/src/test/rules/noSparseArraysRuleTests.ts
@@ -1,27 +1,29 @@
-/// <reference path='../../../typings/mocha/mocha.d.ts' />
-import { makeTest } from './helper';
+import { RuleTester, Failure, Position } from './ruleTester';
 
-const rule = 'no-sparse-arrays';
-const scripts = {
-  valid: [
-    'const items = [];',
-    'const colors = [ "red", "blue", ];',
-    'const arr = new Array(23);'
-  ],
-  invalid: [
-    'const items = [,,];',
-    'const arr = [,];',
-    'const colors = [ "red",, "blue" ];',
-    'const foo = ["tire", 1, , "small ball"];'
-  ]
-};
+const ruleTester = new RuleTester('no-sparse-arrays');
 
-describe(rule, function test() {
-  it('should pass when using valid arrays or trailing comma', function testValid() {
-    makeTest(rule, scripts.valid, true);
+function expecting(errors: [number, number][]): Failure[] {
+  // [line, column]
+  return errors.map((err) => {
+    return {
+      failure: 'unexpected comma in middle of array',
+      startPosition: new Position(err[0], err[1]),
+      endPosition: new Position()
+    };
   });
+}
 
-  it('should fail when using double comma in arrays', function testInvalid() {
-    makeTest(rule, scripts.invalid, false);
-  });
-});
+ruleTester.addTestGroup('valid', 'should pass when using valid arrays or trailing comma', [
+  'const items = [];',
+  'const colors = [ "red", "blue", ];',
+  'const arr = new Array(23);'
+]);
+
+ruleTester.addTestGroup('invalid', 'should fail when using double comma in arrays', [
+  { code: 'const items = [,,];', errors: expecting([[0, 14]])},
+  { code: 'const arr = [,];', errors: expecting([[0, 12]])},
+  { code: 'const colors = [ "red",, "blue" ];', errors: expecting([[0, 15]])},
+  { code: 'const foo = ["tire", 1, , "small ball"];', errors: expecting([[0, 12]])}
+]);
+
+ruleTester.runTests();

--- a/src/test/rules/noSparseArraysRuleTests.ts
+++ b/src/test/rules/noSparseArraysRuleTests.ts
@@ -20,10 +20,10 @@ ruleTester.addTestGroup('valid', 'should pass when using valid arrays or trailin
 ]);
 
 ruleTester.addTestGroup('invalid', 'should fail when using double comma in arrays', [
-  { code: 'const items = [,,];', errors: expecting([[0, 14]])},
-  { code: 'const arr = [,];', errors: expecting([[0, 12]])},
-  { code: 'const colors = [ "red",, "blue" ];', errors: expecting([[0, 15]])},
-  { code: 'const foo = ["tire", 1, , "small ball"];', errors: expecting([[0, 12]])}
+  { code: 'const items = [,,];', errors: expecting([[0, 14]]) },
+  { code: 'const arr = [,];', errors: expecting([[0, 12]]) },
+  { code: 'const colors = [ "red",, "blue" ];', errors: expecting([[0, 15]]) },
+  { code: 'const foo = ["tire", 1, , "small ball"];', errors: expecting([[0, 12]]) }
 ]);
 
 ruleTester.runTests();

--- a/src/test/rules/objectCurlySpacingRuleTests.ts
+++ b/src/test/rules/objectCurlySpacingRuleTests.ts
@@ -1,68 +1,505 @@
-/// <reference path='../../../typings/mocha/mocha.d.ts' />
-import { makeTest, makeFixTest } from './helper';
+import { RuleTester, Failure, Position } from './ruleTester';
 
-const rule = 'object-curly-spacing';
-const scripts = {
-  always: {
-    valid: [
-      `const obj = { foo: 'bar' };`,
-      `const obj = { foo: { zoo: 'bar' } };`,
-      `const { x, y } = y;`,
-      `import { foo } from 'bar';`,
-      `export { foo };`
-    ],
-    invalid: [
-      `const obj = {foo: 'bar'};`,
-      `const obj = {foo: { zoo: 'bar' } };`,
-      `const {x, y} = y;`,
-      `import {foo } from 'bar';`,
-      `export { foo};`
-    ]
+const ruleTester = new RuleTester('object-curly-spacing', true);
+
+function expecting(errors: [number, number, '{' | '}', boolean][]): Failure[] {
+  // [line, column, 'before' | 'after', true means there should be a space]
+  return errors.map((err) => {
+    const status = err[3] ? 'A space is required' : 'There should be no space';
+    const token = err[2] === '}' ? "before '}'" : "after '{'";
+    return {
+      failure: `${status} ${token}`,
+      startPosition: new Position(err[0], err[1]),
+      endPosition: new Position()
+    };
+  });
+}
+
+ruleTester.addTestGroup('always-obj', 'always with object literals', [
+  { code: 'var obj = { foo: bar, baz: qux };', options: ['always'] },
+  { code: 'var obj = { foo: { bar: quxx }, baz: qux };', options: ['always'] },
+  { code: 'var obj = {\nfoo: bar,\nbaz: qux\n};', options: ['always'] }
+]);
+
+ruleTester.addTestGroup('always-dest', 'always with destructuring', [
+  { code: 'var { x } = y', options: ['always'] },
+  { code: 'var { x, y } = y', options: ['always'] },
+  { code: 'var { x,y } = y', options: ['always'] },
+  { code: 'var {\nx,y } = y', options: ['always'] },
+  { code: 'var {\nx,y\n} = z', options: ['always'] },
+  { code: 'var { x = 10, y } = y', options: ['always'] },
+  { code: 'var { x: { z }, y } = y', options: ['always'] },
+  { code: 'var {\ny,\n} = x', options: ['always'] },
+  { code: 'var { y, } = x', options: ['always'] },
+  { code: 'var { y: x } = x', options: ['always'] }
+]);
+
+ruleTester.addTestGroup('always-imp-exp', 'always with import/export', [
+  { code: "import door from 'room'", options: ['always'] },
+  { code: "import * as door from 'room'", options: ['always'] },
+  { code: "import { door } from 'room'", options: ['always'] },
+  { code: "import {\ndoor } from 'room'", options: ['always'] },
+  { code: "export { door } from 'room'", options: ['always'] },
+  { code: "import { house, mouse } from 'caravan'", options: ['always'] },
+  { code: "import house, { mouse } from 'caravan'", options: ['always'] },
+  { code: "import door, { house, mouse } from 'caravan'", options: ['always'] },
+  { code: 'export { door }', options: ['always'] },
+  { code: "import 'room'", options: ['always'] },
+  { code: "import { bar as x } from 'foo';", options: ['always'] },
+  { code: "import { x, } from 'foo';", options: ['always'] },
+  { code: "import {\nx,\n} from 'foo';", options: ['always'] },
+  { code: "export { x, } from 'foo';", options: ['always'] },
+  { code: "export {\nx,\n} from 'foo';", options: ['always'] }
+]);
+
+ruleTester.addTestGroup('empty-object', 'always with empty object', [
+  { code: 'var foo = {};', options: ['always'] }
+]);
+
+/* Disabled: objectsInObjects option is not yet supported
+ruleTester.addTestGroup('obj-obj', 'always with objects in objects', [
+  { code: "var obj = { 'foo': { 'bar': 1, 'baz': 2 }};", options: ['always', { objectsInObjects: false }] },
+  { code: 'var a = { noop: function () {} };', options: ['always', { objectsInObjects: false }] },
+  { code: 'var { y: { z }} = x', options: ['always', { objectsInObjects: false }] }
+]);
+*/
+
+/* Disabled: arraysInObjects option is not yet supported
+ruleTester.addTestGroup('arr-obj', 'always with arrays in objects', [
+  { code: "var obj = { 'foo': [ 1, 2 ]};", options: ['always', { arraysInObjects: false }] },
+  { code: 'var a = { thingInList: list[0] };', options: ['always', { arraysInObjects: false }] }
+]);
+*/
+
+/* Disabled: arraysInObjects option is not yet supported
+ruleTester.addTestGroup('arr-obj-obj', '', [
+  { code: "var obj = { 'qux': [ 1, 2 ], 'foo': { 'bar': 1, 'baz': 2 }};", options: ['always', { arraysInObjects: false, objectsInObjects: false }] },
+  { code: "var obj = { 'foo': { 'bar': 1, 'baz': 2 }, 'qux': [ 1, 2 ]};", options: ['always', { arraysInObjects: false, objectsInObjects: false }] }
+]);
+*/
+
+ruleTester.addTestGroup('never-obj', 'never with object literals', [
+  { code: 'var obj = {foo: bar,\nbaz: qux\n};', options: ['never'] },
+  { code: 'var obj = {\nfoo: bar,\nbaz: qux};', options: ['never'] },
+  { code: 'var obj = {foo: bar, baz: qux};', options: ['never'] },
+  { code: 'var obj = {foo: {bar: quxx}, baz: qux};', options: ['never'] },
+  { code: 'var obj = {foo: {\nbar: quxx}, baz: qux\n};', options: ['never'] },
+  { code: 'var obj = {foo: {\nbar: quxx\n}, baz: qux};', options: ['never'] },
+  { code: 'var obj = {\nfoo: bar,\nbaz: qux\n};', options: ['never'] }
+]);
+
+ruleTester.addTestGroup('never-dest', 'never with destructuring', [
+  { code: 'var {x} = y', options: ['never'] },
+  { code: 'var {x, y} = y', options: ['never'] },
+  { code: 'var {x,y} = y', options: ['never'] },
+  { code: 'var {\nx,y\n} = y', options: ['never'] },
+  { code: 'var {x = 10} = y', options: ['never'] },
+  { code: 'var {x = 10, y} = y', options: ['never'] },
+  { code: 'var {x: {z}, y} = y', options: ['never'] },
+  { code: 'var {\nx: {z\n}, y} = y', options: ['never'] },
+  { code: 'var {\ny,\n} = x', options: ['never'] },
+  { code: 'var {y,} = x', options: ['never'] },
+  { code: 'var {y:x} = x', options: ['never'] }
+]);
+
+ruleTester.addTestGroup('never-imp-exp', 'never with import/export', [
+  { code: "import door from 'room'", options: ['never'] },
+  { code: "import * as door from 'room'", options: ['never'] },
+  { code: "import {door} from 'room'", options: ['never'] },
+  { code: "export {door} from 'room'", options: ['never'] },
+  { code: "import {\ndoor} from 'room'", options: ['never'] },
+  { code: "export {\ndoor\n} from 'room'", options: ['never'] },
+  { code: "import {house,mouse} from 'caravan'", options: ['never'] },
+  { code: "import {house, mouse} from 'caravan'", options: ['never'] },
+  { code: 'export {door}', options: ['never'] },
+  { code: "import 'room'", options: ['never'] },
+  { code: "import x, {bar} from 'foo';", options: ['never'] },
+  { code: "import x, {bar, baz} from 'foo';", options: ['never'] },
+  { code: "import {bar as y} from 'foo';", options: ['never'] },
+  { code: "import {x,} from 'foo';", options: ['never'] },
+  { code: "import {\nx,\n} from 'foo';", options: ['never'] },
+  { code: "export {x,} from 'foo';", options: ['never'] },
+  { code: "export {\nx,\n} from 'foo';", options: ['never'] }
+]);
+
+ruleTester.addTestGroup('empty-object-never', 'never with empty object', [
+  { code: 'var foo = {};', options: ['never'] }
+]);
+
+/* Disabled: objectsInObjects option is not yet supported
+ruleTester.addTestGroup('never-obj-obj', 'never with objects in objects', [
+  { code: "var obj = {'foo': {'bar': 1, 'baz': 2} };", options: ["never", { objectsInObjects: true }] },
+]);
+ */
+
+ruleTester.addTestGroup('empty-cases', 'empty cases: https://github.com/eslint/eslint/issues/3658', [
+  { code: 'var {} = foo;' },
+  { code: 'var [] = foo;' },
+  // { code: 'var {a: {}} = foo;' },
+  // { code: 'var {a: []} = foo;' },
+  { code: "import {} from 'foo';" },
+  { code: "export {} from 'foo';" },
+  { code: 'export {};' },
+  { code: 'var {} = foo;', options: ['never'] },
+  { code: 'var [] = foo;', options: ['never'] },
+  { code: 'var {a: {}} = foo;', options: ['never'] },
+  { code: 'var {a: []} = foo;', options: ['never'] },
+  { code: "import {} from 'foo';", options: ['never'] },
+  { code: "export {} from 'foo';", options: ['never'] },
+  { code: 'export {};', options: ['never'] }
+]);
+
+ruleTester.addTestGroup('types', 'using types: https://github.com/eslint/eslint/issues/6940', [
+  { code: 'function foo ({a, b}: Props) {\n}', options: ['never'] }
+]);
+
+ruleTester.addTestGroup('invalid', 'should fail with invalid code', [
+  {
+    code: "import {bar} from 'foo.js';",
+    output: "import { bar } from 'foo.js';",
+    options: ['always'],
+    errors: expecting([
+      [0, 7, '{', true],
+      [0, 11, '}', true]
+    ])
   },
-  never: {
-    valid: [
-      `const obj = {foo: 'bar'};`,
-      `const obj = {foo: {zoo: 'bar'}};`,
-      `const {x, y} = y;`,
-      `import {foo} from 'bar';`,
-      `export {foo};`
-    ],
-    invalid: [
-      `const obj = { foo: 'bar' };`,
-      `const obj = { foo: { zoo: 'bar' } };`,
-      `const { x, y } = y;`,
-      `import {foo } from 'bar';`,
-      `export { foo};`
-    ]
+  {
+    code: "import { bar as y} from 'foo.js';",
+    output: "import { bar as y } from 'foo.js';",
+    options: ['always'],
+    errors: expecting([
+      [0, 17, '}', true]
+    ])
+  },
+  {
+    code: "import {bar as y} from 'foo.js';",
+    output: "import { bar as y } from 'foo.js';",
+    options: ['always'],
+    errors: expecting([
+      [0, 7, '{', true],
+      [0, 16, '}', true]
+    ])
+  },
+  {
+    code: "import { bar} from 'foo.js';",
+    output: "import { bar } from 'foo.js';",
+    options: ['always'],
+    errors: expecting([
+      [0, 12, '}', true]
+    ])
+  },
+  {
+    code: "import x, { bar} from 'foo';",
+    output: "import x, { bar } from 'foo';",
+    options: ['always'],
+    errors: expecting([
+      [0, 15, '}', true]
+    ])
+  },
+  {
+    code: "import x, { bar, baz} from 'foo';",
+    output: "import x, { bar, baz } from 'foo';",
+    options: ['always'],
+    errors: expecting([
+      [0, 20, '}', true]
+    ])
+  },
+  {
+    code: "import x, {bar} from 'foo';",
+    output: "import x, { bar } from 'foo';",
+    options: ['always'],
+    errors: expecting([
+      [0, 10, '{', true],
+      [0, 14, '}', true]
+    ])
+  },
+  {
+    code: "import x, {bar, baz} from 'foo';",
+    output: "import x, { bar, baz } from 'foo';",
+    options: ['always'],
+    errors: expecting([
+      [0, 10, '{', true],
+      [0, 19, '}', true]
+    ])
+  },
+  {
+    code: "import {bar,} from 'foo';",
+    output: "import { bar, } from 'foo';",
+    options: ['always'],
+    errors: expecting([
+      [0, 7, '{', true],
+      [0, 12, '}', true]
+    ])
+  },
+  {
+    code: "import { bar, } from 'foo';",
+    output: "import {bar,} from 'foo';",
+    options: ['never'],
+    errors: expecting([
+      [0, 7, '{', false],
+      [0, 14, '}', false]
+    ])
+  },
+  {
+    code: 'export {bar};',
+    output: 'export { bar };',
+    options: ['always'],
+    errors: expecting([
+      [0, 7, '{', true],
+      [0, 11, '}', true]
+    ])
   }
-};
+]);
 
-describe(rule, function test() {
+/* Disabled objectsInObjects option is not yet supported
+ruleTester.addTestGroup('invalid-always-arr-obj', 'invalid always - arrays in objects', [
+  {
+    code: "var obj = { 'foo': [ 1, 2 ] };",
+    output: "var obj = { 'foo': [ 1, 2 ]};",
+    options: ['always', { arraysInObjects: false }]
+  },
+  {
+    code: "var obj = { 'foo': [ 1, 2 ] , 'bar': [ 'baz', 'qux' ] };",
+    output: "var obj = { 'foo': [ 1, 2 ] , 'bar': [ 'baz', 'qux' ]};",
+    options: ['always', { arraysInObjects: false }]
+  }
+]);
+*/
 
-  const alwaysConfig = { rules: { 'object-curly-spacing': [true, 'always'] } };
-  const neverConfig = { rules: { 'object-curly-spacing': [true, 'never'] } };
+/* Disabled objectsInObjects option is not yet supported
+ruleTester.addTestGroup('invalid-obj-obj', 'invalid always - objects in objects', [
+  {
+    code: "var obj = { 'foo': { 'bar': 1, 'baz': 2 } };",
+    output: "var obj = { 'foo': { 'bar': 1, 'baz': 2 }};",
+    options: ['always', { objectsInObjects: false }],
+    errors: expecting([
+      [0, 42, '}', false]
+    ])
+  },
+  {
+    code: "var obj = { 'foo': [ 1, 2 ] , 'bar': { 'baz': 1, 'qux': 2 } };",
+    output: "var obj = { 'foo': [ 1, 2 ] , 'bar': { 'baz': 1, 'qux': 2 }};",
+    options: ['always', { objectsInObjects: false }],
+    errors: expecting([
+      [0, 60, '}', false]
+    ])
+  }
+]);
+*/
 
-  it('should pass when "always" and there are spaces inside brackets', function testVariables() {
-    makeTest(rule, scripts.always.valid, true, alwaysConfig);
-  });
+ruleTester.addTestGroup('invalid-always-dest', 'invalid always - destructuring trailing comma', [
+  {
+    code: 'var { a,} = x;',
+    output: 'var { a, } = x;',
+    options: ['always'],
+    errors: expecting([
+      [0, 8, '}', true]
+    ])
+  },
+  {
+    code: 'var {a, } = x;',
+    output: 'var {a,} = x;',
+    options: ['never'],
+    errors: expecting([
+      [0, 8, '}', false]
+    ])
+  },
+  {
+    code: 'var {a:b } = x;',
+    output: 'var {a:b} = x;',
+    options: ['never'],
+    errors: expecting([
+      [0, 9, '}', false]
+    ])
+  },
+  {
+    code: 'var { a:b } = x;',
+    output: 'var {a:b} = x;',
+    options: ['never'],
+    errors: expecting([
+      [0, 4, '{', false],
+      [0, 10, '}', false]
+    ])
+  }
+]);
 
-  it('should fail when "always" and there are not spaces inside brackets', function testVariables() {
-    makeTest(rule, scripts.always.invalid, false, alwaysConfig);
-  });
+/* Disabled objectsInObjects option is not yet supported
+ruleTester.addTestGroup('invalid-never-obj-obj', 'invalid never - objects in objects', [
+  {
+    code: "var obj = {'foo': {'bar': 1, 'baz': 2}};",
+    output: "var obj = {'foo': {'bar': 1, 'baz': 2} };",
+    options: ['never', { objectsInObjects: true }],
+    errors: expecting([
+      [0, 38, '}', true]
+    ])
+  },
+  {
+    code: "var obj = {'foo': [1, 2] , 'bar': {'baz': 1, 'qux': 2}};",
+    output: "var obj = {'foo': [1, 2] , 'bar': {'baz': 1, 'qux': 2} };",
+    options: ['never', { objectsInObjects: true }],
+    errors: expecting([
+      [0, 54, '}', true]
+    ])
+  }
+]);
+*/
 
-  it('should add necessary spaces when "always" with fix option', function testVariables() {
-    makeFixTest(rule, scripts.always.invalid, scripts.always.valid, alwaysConfig);
-  });
+/* Disabled objectsInObjects option is not yet supported
+ruleTester.addTestGroup('invalid-never-arr-obj', 'invalid never - arrays in objects', [
+  {
+    code: "var obj = {'foo': [1, 2]};",
+    output: "var obj = {'foo': [1, 2] };",
+    options: ['never', { arraysInObjects: true }]
+  },
+  {
+    code: "var obj = {'foo': [1, 2] , 'bar': ['baz', 'qux']};",
+    output: "var obj = {'foo': [1, 2] , 'bar': ['baz', 'qux'] };",
+    options: ['never', { arraysInObjects: true }]
+  }
+]);
+*/
 
-  it('should pass when "never" and there are not spaces inside brackets', function testVariables() {
-    makeTest(rule, scripts.never.valid, true, neverConfig);
-  });
+ruleTester.addTestGroup('invalid-always-never', 'invalid always/never', [
+  {
+    code: 'var obj = {foo: bar, baz: qux};',
+    output: 'var obj = { foo: bar, baz: qux };',
+    options: ['always'],
+    errors: expecting([
+      [0, 10, '{', true],
+      [0, 29, '}', true]
+    ])
+  },
+  {
+    code: 'var obj = {foo: bar, baz: qux };',
+    output: 'var obj = { foo: bar, baz: qux };',
+    options: ['always'],
+    errors: expecting([
+      [0, 10, '{', true]
+    ])
+  },
+  {
+    code: 'var obj = { foo: bar, baz: qux};',
+    output: 'var obj = { foo: bar, baz: qux };',
+    options: ['always'],
+    errors: expecting([
+      [0, 30, '}', true]
+    ])
+  },
+  {
+    code: 'var obj = { foo: bar, baz: qux };',
+    output: 'var obj = {foo: bar, baz: qux};',
+    options: ['never'],
+    errors: expecting([
+      [0, 10, '{', false],
+      [0, 31, '}', false]
+    ])
+  },
+  {
+    code: 'var obj = {foo: bar, baz: qux };',
+    output: 'var obj = {foo: bar, baz: qux};',
+    options: ['never'],
+    errors: expecting([
+      [0, 30, '}', false]
+    ])
+  },
+  {
+    code: 'var obj = { foo: bar, baz: qux};',
+    output: 'var obj = {foo: bar, baz: qux};',
+    options: ['never'],
+    errors: expecting([
+      [0, 10, '{', false]
+    ])
+  },
+  {
+    code: 'var obj = { foo: { bar: quxx}, baz: qux};',
+    output: 'var obj = {foo: {bar: quxx}, baz: qux};',
+    options: ['never'],
+    errors: expecting([
+      [0, 10, '{', false],
+      [0, 17, '{', false]
+    ])
+  },
+  {
+    code: 'var obj = {foo: {bar: quxx }, baz: qux };',
+    output: 'var obj = {foo: {bar: quxx}, baz: qux};',
+    options: ['never'],
+    errors: expecting([
+      [0, 27, '}', false],
+      [0, 39, '}', false]
+    ])
+  },
+  {
+    code: 'export const thing = {value: 1 };',
+    output: 'export const thing = { value: 1 };',
+    options: ['always'],
+    errors: expecting([
+      [0, 21, '{', true]
+    ])
+  }
+]);
 
-  it('should fail when "never" and there are spaces inside brackets', function testVariables() {
-    makeTest(rule, scripts.never.invalid, false, neverConfig);
-  });
+ruleTester.addTestGroup('invalid-dest', 'invalid destructuring', [
+  {
+    code: 'var {x, y} = y',
+    output: 'var { x, y } = y',
+    options: ['always'],
+    errors: expecting([
+      [0, 4, '{', true],
+      [0, 9, '}', true]
+    ])
+  },
+  {
+    code: 'var { x, y} = y',
+    output: 'var { x, y } = y',
+    options: ['always'],
+    errors: expecting([
+      [0, 10, '}', true]
+    ])
+  },
+  {
+    code: 'var { x, y } = y',
+    output: 'var {x, y} = y',
+    options: ['never'],
+    errors: expecting([
+      [0, 4, '{', false],
+      [0, 11, '}', false]
+    ])
+  },
+  {
+    code: 'var {x, y } = y',
+    output: 'var {x, y} = y',
+    options: ['never'],
+    errors: expecting([
+      [0, 10, '}', false]
+    ])
+  },
+  {
+    code: 'var { x=10} = y',
+    output: 'var { x=10 } = y',
+    options: ['always'],
+    errors: expecting([
+      [0, 10, '}', true]
+    ])
+  },
+  {
+    code: 'var {x=10 } = y',
+    output: 'var { x=10 } = y',
+    options: ['always'],
+    errors: expecting([
+      [0, 4, '{', true]
+    ])
+  }
+]);
 
-  it('should remove unnecessary spaces when "never" with fix option', function testVariables() {
-    makeFixTest(rule, scripts.never.invalid, scripts.never.valid, neverConfig);
-  });
-});
+ruleTester.addTestGroup('eslint-6940', 'https://github.com/eslint/eslint/issues/6940', [
+  {
+    code: 'function foo ({a, b }: Props) {\n}',
+    output: 'function foo ({a, b}: Props) {\n}',
+    options: ['never'],
+    errors: expecting([
+      [0, 20, '}', false]
+    ])
+  }
+]);
+
+ruleTester.runTests();

--- a/src/test/rules/ruleTester.ts
+++ b/src/test/rules/ruleTester.ts
@@ -243,7 +243,8 @@ class TestGroup {
     description: string,
     ruleName: string,
     tests: (ITest | string)[],
-    testFixer: boolean = false
+    testFixer: boolean = false,
+    groupConfig: any = null
   ) {
     this.name = name;
     this.ruleName = ruleName;
@@ -252,10 +253,15 @@ class TestGroup {
       const config: any = { rules: { [ruleName]: true } };
       const codeFileName = `${name}-${index}.ts`;
       if (typeof test === 'string') {
+        if (groupConfig) {
+          config.rules[ruleName] = [true, ...groupConfig];
+        }
         return new Test(codeFileName, test, undefined, config, []);
       }
       if (test.options) {
         config.rules[ruleName] = [true, ...test.options];
+      } else if (groupConfig) {
+        config.rules[ruleName] = [true, ...groupConfig];
       }
       const failures: LintFailure[] = (test.errors || []).map((error) => {
         return new LintFailure(
@@ -283,6 +289,26 @@ class RuleTester {
 
   public addTestGroup(name: string, description: string, tests: (ITest | string)[]): this {
     this.groups.push(new TestGroup(name, description, this.ruleName, tests, this.testFixer));
+    return this;
+  }
+
+  /**
+   * Appends a test group to run under a configuration. This configuration can be overwritten
+   * by providing a configuration in the test.
+   *
+   * @param name Test identifier
+   * @param description Test description
+   * @param groupConfig The configuration for the group
+   * @param tests A list of string or ITest objects.
+   * @return {RuleTester}
+   */
+  public addTestGroupWithConfig(
+    name: string,
+    description: string,
+    groupConfig: any,
+    tests: (ITest | string)[]
+  ): this {
+    this.groups.push(new TestGroup(name, description, this.ruleName, tests, this.testFixer, groupConfig));
     return this;
   }
 

--- a/src/test/rules/validJsdocRuleTests.ts
+++ b/src/test/rules/validJsdocRuleTests.ts
@@ -1,105 +1,128 @@
-/// <reference path='../../../typings/mocha/mocha.d.ts' />
-import { makeTest } from './helper';
+import { dedent, RuleTester, Failure, Position } from './ruleTester';
 
-const rule = 'valid-jsdoc';
-const scripts = {
-  validDefault: [
-    `/**
-      * Description
-       * @param {Object[]} screenings Array of screenings.
-       * @param {Number} screenings[].timestamp its a time stamp
-       @return {void} */
-      function foo(){}`,
-    `/**
-      * Description
+const MATCH_DESCRIPTION_TEST = '^[A-Z][A-Za-z0-9\\s]*[.]$';
+const ruleTester = new RuleTester('valid-jsdoc');
+
+// Only checking for message
+function expecting(errors: string[]): Failure[] {
+  return errors.map((err) => {
+    return {
+      failure: err,
+      startPosition: new Position(),
+      endPosition: new Position()
+    };
+  });
+}
+
+ruleTester.addTestGroup('valid-default', 'should pass when using valid JSDoc comments (default options)', [
+  `/**
+    * Description
+     * @param {Object[]} screenings Array of screenings.
+     * @param {Number} screenings[].timestamp its a time stamp
+     @return {void} */
+    function foo(){}`,
+  `/**
+    * Description
+     */
+    var x = new Foo(function foo(){})`,
+  `/**
+    * Description
+    * @returns {void} */
+    function foo(){}`,
+  `/**
+    * Description
+    * @returns {undefined} */
+    function foo(){}`,
+  `/**
+    * Description
+    * @alias Test#test
+    * @returns {void} */
+    function foo(){}`,
+  `/**
+    * Description
+    *@extends MyClass
+    * @returns {void} */
+    function foo(){}`,
+  `/**
+    * Description
+    * @constructor */
+    function Foo(){}`,
+  `/**
+    * Description
+    * @class */
+    function Foo(){}`,
+  `/**
+    * Description
+    * @param {string} p bar
+    * @returns {string} desc */
+    function foo(p){}`,
+  `/**
+    * Description
+    * @arg {string} p bar
+    * @returns {string} desc */
+    function foo(p){}`,
+  `/**
+    * Description
+    * @argument {string} p bar
+    * @returns {string} desc */
+    function foo(p){}`,
+  `/**
+    * Description
+    * @param {string} [p] bar
+    * @returns {string} desc */
+    function foo(p){}`,
+  `/**
+    * Description
+    * @param {Object} p bar
+    * @param {string} p.name bar
+    * @returns {string} desc */
+    Foo.bar = function(p){};`,
+  `(function(){
+    /**
+    * Description
+    * @param {string} p bar
+    * @returns {string} desc */
+    function foo(p){}
+    }())`,
+  `var o = {
+    /**
+    * Description
+    * @param {string} p bar
+    * @returns {string} desc */
+    foo: function(p){}
+    };`,
+  `/**
+    * Description
+    * @param {Object} p bar
+    * @param {string[]} p.files qux
+    * @param {Function} cb baz
+    * @returns {void} */
+    function foo(p, cb){}`,
+  `/**
+    * Description
+    * @override */
+    function foo(arg1, arg2){ return ''; }`,
+  `/**
+    * Description
+    * @inheritdoc */
+    function foo(arg1, arg2){ return ''; }`,
+  `/**
+    * Description
+    * @return {void} */
+    function foo(){}`,
+  `/**
+   * Description for A.
+   */
+  class A {
+      /**
+       * Description for constructor.
+       * @param {object[]} xs - xs
+       * @returns {void}
        */
-      var x = new Foo(function foo(){})`,
-    `/**
-      * Description
-      * @returns {void} */
-      function foo(){}`,
-    `/**
-      * Description
-      * @returns {undefined} */
-      function foo(){}`,
-    `/**
-      * Description
-      * @alias Test#test
-      * @returns {void} */
-      function foo(){}`,
-    `/**
-      * Description
-      *@extends MyClass
-      * @returns {void} */
-      function foo(){}`,
-    `/**
-      * Description
-      * @constructor */
-      function Foo(){}`,
-    `/**
-      * Description
-      * @class */
-      function Foo(){}`,
-    `/**
-      * Description
-      * @param {string} p bar
-      * @returns {string} desc */
-      function foo(p){}`,
-    `/**
-      * Description
-      * @arg {string} p bar
-      * @returns {string} desc */
-      function foo(p){}`,
-    `/**
-      * Description
-      * @argument {string} p bar
-      * @returns {string} desc */
-      function foo(p){}`,
-    `/**
-      * Description
-      * @param {string} [p] bar
-      * @returns {string} desc */
-      function foo(p){}`,
-    `/**
-      * Description
-      * @param {Object} p bar
-      * @param {string} p.name bar
-      * @returns {string} desc */
-      Foo.bar = function(p){};`,
-    `(function(){
-      /**
-      * Description
-      * @param {string} p bar
-      * @returns {string} desc */
-      function foo(p){}
-      }())`,
-    `var o = {
-      /**
-      * Description
-      * @param {string} p bar
-      * @returns {string} desc */
-      foo: function(p){}
-      };`,
-    `/**
-      * Description
-      * @param {Object} p bar
-      * @param {string[]} p.files qux
-      * @param {Function} cb baz
-      * @returns {void} */
-      function foo(p, cb){}`,
-    `/**
-      * Description
-      * @override */
-      function foo(arg1, arg2){ return ''; }`,
-    `/**
-      * Description
-      * @inheritdoc */
-      function foo(arg1, arg2){ return ''; }`,
-    `/**
-      * Description
-      * @return {void} */
-      function foo(){}`,
-    `/**
+      constructor(xs) {
+          this.a = xs;    }
+  }`,
+  `/**
      * Description for A.
      */
     class A {
@@ -110,28 +133,21 @@ const scripts = {
          */
         constructor(xs) {
             this.a = xs;    }
-    }`,
-    `/**
-       * Description for A.
-       */
-      class A {
-          /**
-           * Description for constructor.
-           * @param {object[]} xs - xs
-           * @returns {void}
-           */
-          constructor(xs) {
-              this.a = xs;    }
-          /**
-           * Description for method.
-           * @param {object[]} xs - xs
-           * @returns {void}
-           */
-          print(xs) {
-              this.a = xs;    }
-      }`
-  ],
-  validNoRequireReturn: [
+        /**
+         * Description for method.
+         * @param {object[]} xs - xs
+         * @returns {void}
+         */
+        print(xs) {
+            this.a = xs;    }
+    }`
+]);
+
+ruleTester.addTestGroupWithConfig(
+  'no-require-return',
+  'should pass when using valid JSDoc comments (requireReturn: false)',
+  { requireReturn: false },
+  [
     `/**
       * Description
       * @param {string} p bar
@@ -216,329 +232,419 @@ const scripts = {
           constructor(xs) {
               this.a = xs;    }
       }`
-  ],
-  validNoRequireParamDescription: [
+  ]
+);
+
+ruleTester.addTestGroupWithConfig(
+  'no-require-param-desc',
+  'should pass when using valid JSDoc comments (requireParamDescription: false)',
+  { requireParamDescription: false },
+  [
     `/**
       * Description
       * @param {string} p
       * @returns {void}*/
       Foo.bar = function(p){var t = function(){function name(){}; return name;}};`
-  ],
-  validNoRequireReturnDescription: [
+  ]
+);
+
+ruleTester.addTestGroupWithConfig(
+  'no-require-ret-desc',
+  'should pass when using valid JSDoc comments (requireReturnDescription: false)',
+  { requireReturnDescription: false },
+  [
     `/**
       * Description
       * @param {string} p mytest
       * @returns {Object}*/
       Foo.bar = function(p){return name;};`
-  ],
-  validMatchDescription: [
+  ]
+);
+
+ruleTester.addTestGroupWithConfig(
+  'match-desc',
+  'should pass when using valid JSDoc comments (matchDescription: "regex")',
+  { matchDescription: MATCH_DESCRIPTION_TEST },
+  [
     `/**
       * Start with caps and end with period.
       * @return {void} */
       function foo(){}`
-  ],
-  validPrefer: [
+  ]
+);
+
+ruleTester.addTestGroupWithConfig(
+  'prefer',
+  'should pass when using valid JSDoc comments (prefer: { return: "return" })',
+  { prefer: { 'return': 'return' } },
+  [
     `/** Foo
       @return {void} Foo
        */
       function foo(){}`
-  ],
-  invalidDefault: [
-    `/** @@foo */
-      function foo(){}`,
-    `/** @@returns {void} Foo */
-      function foo(){}`,
-    `/** Foo
-      @returns {void Foo
-       */
-      function foo(){}`,
-    `/** Foo
-    @param {void Foo
-     */
-    function foo(){}`,
-    `/** Foo
-      @param {} p Bar
-       */
-      function foo(){}`,
-    `/** Foo
-      @param {void Foo */
-      function foo(){}`,
-    `/** Foo
-      * @param p Desc
-      */
-      function foo(){}`,
-    `/**
-      * Foo
-      * @param {string} p
-      */
-      function foo(){}`,
-    `/**
-      * Foo
-      * @returns {string}
-      */
-      function foo(){}`,
-    `/**
-      * Foo
-      * @returns {string} something
-      */
-      function foo(p){}`,
-    `/**
-      * Foo
-      * @param {string} p desc
-      * @param {string} p desc
-      */
-      function foo(){}`,
-    `/**
-      * Foo
-      * @param {string} a desc
-      @returns {void}*/
-      function foo(b){}`,
-    `/**
-      * Foo
-      * @override
-      * @param {string} a desc
-       */
-      function foo(b){}`,
-    `/**
-      * Foo
-      * @inheritdoc
-      * @param {string} a desc
-       */
-      function foo(b){}`,
-    `/**
-      * @param fields [Array]
+  ]
+);
+
+ruleTester.addTestGroup('invalid', 'should fail when using invalid JSDoc comments (default)', [
+  {
+    code: dedent`
+      /** @@foo */
+       function foo(){}`,
+    errors: expecting(['JSDoc syntax error'])
+  },
+  {
+    code: dedent`
+      /** @@returns {void} Foo */
+        function foo(){}`,
+    errors: expecting(['JSDoc syntax error'])
+  },
+  {
+    code: dedent`
+      /** Foo
+        @returns {void Foo
+         */
+        function foo(){}`,
+    errors: expecting(['JSDoc type missing brace'])
+  },
+  {
+    code: dedent`
+      /** Foo
+       @param {void Foo
+        */
+       function foo(){}`,
+    errors: expecting(['JSDoc type missing brace'])
+  },
+  {
+    code: dedent`
+      /** Foo
+       @param {} p Bar
+        */
+       function foo(){}`,
+    errors: expecting(['JSDoc syntax error'])
+  },
+  {
+    code: dedent`
+      /** Foo
+       @param {void Foo */
+       function foo(){}`,
+    errors: expecting(['JSDoc type missing brace'])
+  },
+  {
+    code: dedent`
+      /** Foo
+       @param {void Foo */
+       function foo(){}`,
+    errors: expecting(['JSDoc type missing brace'])
+  },
+  {
+    code: dedent`
+      /** Foo
+       * @param p Desc
        */
        function foo(){}`,
-    `/**
-       * Description for A.
+    errors: expecting([
+      "missing JSDoc parameter type for 'p'",
+      'missing JSDoc @returns for function'
+    ])
+  },
+  {
+    code: dedent`
+      /**
+       * Foo
+       * @param {string} p
        */
-      class A {
-          /**
-           * Description for constructor.
-           * @param {object[]} xs - xs
-           * @returns {void}
-           */
-          constructor(xs) {
-              this.a = xs;    }
-          /**
-           * Description for method.
-           */
-          print(xs) {
-              this.a = xs;    }
-      }`
-  ],
-  invalidPreferReturnReturns: [
-    `/** Foo
-      @return {void} Foo
+       function foo(){}`,
+    errors: expecting([
+      "missing JSDoc parameter description for 'p'",
+      'missing JSDoc @returns for function'
+    ])
+  },
+  {
+    code: dedent`
+      /**
+       * Foo
+       * @returns {string}
        */
-      function foo(){}`,
-    `/** Foo
-      @return {void} Foo
+       function foo(){}`,
+    errors: expecting(['missing JSDoc return description'])
+  },
+  {
+    code: dedent`
+      /**
+       * Foo
+       * @returns {string} something
        */
-      foo.bar = () => {}`,
-    `/**
-     * Does something.
-    * @param {string} a - this is a
-    * @return {Array<number>} The result of doing it
-    */
-     export function doSomething(a) { }`,
-    `/**
-       * Does something.
-      * @param {string} a - this is a
-      * @return {Array<number>} The result of doing it
-      */
-       export default function doSomething(a) { }`
-  ],
-  invalidPreferArgumentArg: [
-    `/** Foo
-      @argument {int} bar baz
+       function foo(p){}`,
+    errors: expecting(["missing JSDoc for parameter 'p'"])
+  },
+  {
+    code: dedent`
+      /**
+       * Foo
+       * @param {string} p desc
+       * @param {string} p desc
        */
-      function foo(bar){}`
-  ],
-  invalidPreferReturnsReturn: [
-    `/** Foo
+       function foo(){}`,
+    errors: expecting([
+      "duplicate JSDoc parameter 'p'",
+      'missing JSDoc @returns for function'
+    ])
+  },
+  {
+    code: dedent`
+      /**
+       * Foo
+       * @param {string} a desc
+       @returns {void}*/
+       function foo(b){}`,
+    errors: expecting(["expected JSDoc for 'b' but found 'a'"])
+  },
+  {
+    code: dedent`
+      /**
+       * Foo
+       * @override
+       * @param {string} a desc
+        */
+       function foo(b){}`,
+    errors: expecting(["expected JSDoc for 'b' but found 'a'"])
+  },
+  {
+    code: dedent`
+      /**
+       * Foo
+       * @inheritdoc
+       * @param {string} a desc
+        */
+       function foo(b){}`,
+    errors: expecting(["expected JSDoc for 'b' but found 'a'"])
+  },
+  {
+    code: dedent`
+      /**
+       * @param fields [Array]
+        */
+        function foo(){}`,
+    errors: expecting([
+      "missing JSDoc parameter type for 'fields'",
+      'missing JSDoc @returns for function'
+    ])
+  },
+  {
+    code: dedent`
+      /**
+        * Description for A.
+        */
+       class A {
+           /**
+            * Description for constructor.
+            * @param {object[]} xs - xs
+            * @returns {void}
+            */
+           constructor(xs) {
+               this.a = xs;    }
+           /**
+            * Description for method.
+            */
+           print(xs) {
+               this.a = xs;    }
+       }
+    `,
+    errors: expecting([
+      'missing JSDoc @returns for function',
+      "missing JSDoc for parameter 'xs'"
+    ])
+  }
+]);
+
+ruleTester.addTestGroupWithConfig(
+  'invalid-pref-ret',
+  'should fail when using invalid JSDoc comments (prefer: { return: "returns" })',
+  { prefer: { 'return': 'returns' } },
+  [
+    {
+      code: dedent`
+        /** Foo
+         @return {void} Foo
+          */
+         function foo(){}`,
+      errors: expecting(['use @returns instead'])
+    },
+    {
+      code: dedent`
+        /** Foo
+         @return {void} Foo
+          */
+         foo.bar = () => {}`,
+      errors: expecting(['use @returns instead'])
+    },
+    {
+      code: dedent`
+        /**
+        * Does something.
+       * @param {string} a - this is a
+       * @return {Array<number>} The result of doing it
        */
-      function foo(){}`
-  ],
-  invalidNoRequireReturn: [
-    `/**
-      * Foo
-      * @param {string} a desc
-      */
-      function foo(a){var t = false; if(t) {return t;}}`,
-    `/**
-      * Foo
-      * @param {string} a desc
-      */
-      function foo(a){var t = false; if(t) {return null;}}`,
-    `/**
-      * Foo
-      * @param {string} a desc
-      @returns {MyClass}*/
-      function foo(a){var t = false; if(t) {process(t);}}`,
-    `/** foo */ var foo = () => bar();`,
-    `/** foo */ var foo = () => { return bar(); };`,
-    `/** @returns {object} foo */ var foo = () => { bar(); };`
-  ],
-  invalidMatchDescription: [
-    `/**
-      * Start with caps and end with period
-      * @return {void} */
-      function foo(){}`
-  ],
-  invalidNoRequireReturnAndMatchDescription: [
-    `/**
-       * Description for A
-       */
-      class A {
-          /**
-           * Description for constructor
-           * @param {object[]} xs - xs
-           */
-          constructor(xs) {
-              this.a = xs;    }
-      }`,
-    `/**
-       * Description for a
-       */
-      var A = class {
-          /**
-           * Description for constructor.
-           * @param {object[]} xs - xs
-           */
-          constructor(xs) {
-              this.a = xs;    }
-      };`
+        export function doSomething(a) { }`,
+      errors: expecting(['use @returns instead'])
+    },
+    {
+      code: dedent`
+        /**
+          * Does something.
+         * @param {string} a - this is a
+         * @return {Array<number>} The result of doing it
+         */
+          export default function doSomething(a) { }
+      `,
+      errors: expecting(['use @returns instead'])
+    }
   ]
-};
+);
 
-const MATCH_DESCRIPTION_TEST = '^[A-Z][A-Za-z0-9\\s]*[.]$';
+ruleTester.addTestGroupWithConfig(
+  'invalid-pref-arg',
+  'should fail when using invalid JSDoc comments (prefer: { argument: "arg" })',
+  { prefer: { 'argument': 'arg' } },
+  [
+    {
+      code: dedent`
+        /** Foo
+         @argument {int} bar baz
+          */
+         function foo(bar){}`,
+      errors: expecting([
+        'use @arg instead',
+        'missing JSDoc @returns for function'
+      ])
+    }
+  ]
+);
 
-describe(rule, function test() {
-  it('should pass when using valid JSDoc comments (default options)', function testValidDefault() {
-    makeTest(rule, scripts.validDefault, true);
-  });
+ruleTester.addTestGroupWithConfig(
+  'invalid-pref-rets-ret',
+  'should fail when using invalid JSDoc comments (prefer: { returns: "return" })',
+  { prefer: { 'returns': 'return' } },
+  [
+    {
+      code: dedent`
+        /** Foo
+         */
+        function foo(){}`,
+      errors: expecting(['missing JSDoc @return for function'])
+    }
+  ]
+);
 
-  it('should pass when using valid JSDoc comments (requireReturn: false)', function testValidNoRequireReturn() {
-    makeTest(rule, scripts.validNoRequireReturn, true, {
-      rules: {
-        [rule]: [true, {
-          requireReturn: false
-        }]
-      }
-    });
-  });
+ruleTester.addTestGroupWithConfig(
+  'invalid-match-desc',
+  'should fail when using invalid JSDoc comments (matchDescription: "regex")',
+  { matchDescription: MATCH_DESCRIPTION_TEST },
+  [
+    {
+      code: dedent`
+        /**
+         * Start with caps and end with period
+         * @return {void} */
+         function foo(){}`,
+      errors: expecting(['JSDoc description does not satisfy the regex pattern'])
+    }
+  ]
+);
 
-  it('should pass when using valid JSDoc comments (requireReturnDescription: false)', function testValidNoRequireReturnDescription() {
-    makeTest(rule, scripts.validNoRequireReturnDescription, true, {
-      rules: {
-        [rule]: [true, {
-          requireReturnDescription: false
-        }]
-      }
-    });
-  });
+ruleTester.addTestGroupWithConfig(
+  'invalid-no-req-ret',
+  'should fail when using invalid JSDoc comments (requireReturn: false)',
+  [{ requireReturn: false }],
+  [
+    {
+      code: dedent`
+        /**
+         * Foo
+         * @param {string} a desc
+         */
+         function foo(a){var t = false; if(t) {return t;}}`,
+      errors: expecting(['missing JSDoc @return for function'])
+    },
+    {
+      code: dedent`
+        /**
+         * Foo
+         * @param {string} a desc
+         */
+         function foo(a){var t = false; if(t) {return null;}}`,
+      errors: expecting(['missing JSDoc @return for function'])
+    },
+    {
+      code: dedent`
+        /**
+         * Foo
+         * @param {string} a desc
+         @returns {MyClass}*/
+         function foo(a){var t = false; if(t) {process(t);}}`,
+      errors: expecting([
+        'unexpected @returns tag; function has no return statement',
+        'use @return instead'
+      ])
+    },
+    {
+      code: '/** foo */ var foo = () => bar();',
+      errors: expecting(['missing JSDoc @return for function'])
+    },
+    {
+      code: '/** foo */ var foo = () => { return bar(); };',
+      errors: expecting(['missing JSDoc @return for function'])
+    },
+    {
+      code: '/** @returns {object} foo */ var foo = () => { bar(); };',
+      errors: expecting([
+        'unexpected @returns tag; function has no return statement',
+        'use @return instead'
+      ])
+    }
+  ]
+);
 
-  it('should pass when using valid JSDoc comments (requireParamDescription: false)', function testValidNoRequireParamDescription() {
-    makeTest(rule, scripts.validNoRequireParamDescription, true, {
-      rules: {
-        [rule]: [true, {
-          requireParamDescription: false
-        }]
-      }
-    });
-  });
+ruleTester.addTestGroupWithConfig(
+  'invalid-req-ret-match',
+  'should fail when using invalid JSDoc comments (matchDescription: "regex", requireReturn: false)',
+  {
+    requireReturn: false,
+    matchDescription: MATCH_DESCRIPTION_TEST
+  },
+  [
+    {
+      code: dedent`
+        /**
+          * Description for A
+          */
+         class A {
+             /**
+              * Description for constructor
+              * @param {object[]} xs - xs
+              */
+             constructor(xs) {
+                 this.a = xs;    }
+         }`,
+      errors: expecting(['JSDoc description does not satisfy the regex pattern'])
+    },
+    {
+      code: dedent`
+        /**
+          * Description for a
+          */
+         var A = class {
+             /**
+              * Description for constructor.
+              * @param {object[]} xs - xs
+              */
+             constructor(xs) {
+                 this.a = xs;    }
+         };
+      `,
+      errors: expecting(['JSDoc description does not satisfy the regex pattern'])
+    }
+  ]
+);
 
-  it('should pass when using valid JSDoc comments (matchDescription: "regex")', function testValidMatchDescription() {
-    makeTest(rule, scripts.validMatchDescription, true, {
-      rules: {
-        [rule]: [true, {
-          matchDescription: MATCH_DESCRIPTION_TEST
-        }]
-      }
-    });
-  });
-
-  it('should pass when using valid JSDoc comments (prefer: { return: "return" })', function testValidPrefer() {
-    makeTest(rule, scripts.validPrefer, true, {
-      rules: {
-        [rule]: [true, {
-          prefer: {
-            'return': 'return'
-          }
-        }]
-      }
-    });
-  });
-
-  it('should fail when using invalid JSDoc comments (default)', function testInvalidDefault() {
-    makeTest(rule, scripts.invalidDefault, false);
-  });
-
-  it('should fail when using invalid JSDoc comments (prefer: { return: "returns" })', function testInvalidPreferReturnReturns() {
-    makeTest(rule, scripts.invalidPreferReturnReturns, false, {
-      rules: {
-        [rule]: [true, {
-          prefer: {
-            'return': 'returns'
-          }
-        }]
-      }
-    });
-  });
-
-  it('should fail when using invalid JSDoc comments (prefer: { returns: "return" })', function testInvalidPreferReturnsReturn() {
-    makeTest(rule, scripts.invalidPreferReturnsReturn, false, {
-      rules: {
-        [rule]: [true, {
-          prefer: {
-            'returns': 'return'
-          }
-        }]
-      }
-    });
-  });
-
-  it('should fail when using invalid JSDoc comments (prefer: { argument: "arg" })', function testInvalidPreferArgumentArg() {
-    makeTest(rule, scripts.invalidPreferArgumentArg, false, {
-      rules: {
-        [rule]: [true, {
-          prefer: {
-            'argument': 'arg'
-          }
-        }]
-      }
-    });
-  });
-
-  it('should fail when using invalid JSDoc comments (requireReturn: false)', function testInvalidNoRequireReturn() {
-    makeTest(rule, scripts.invalidNoRequireReturn, false, {
-      rules: {
-        [rule]: [true, {
-          requireReturn: false
-        }]
-      }
-    });
-  });
-
-  it('should fail when using invalid JSDoc comments (matchDescription: "regex")', function testInvalidMatchDescription() {
-    makeTest(rule, scripts.invalidMatchDescription, false, {
-      rules: {
-        [rule]: [true, {
-          matchDescription: MATCH_DESCRIPTION_TEST
-        }]
-      }
-    });
-  });
-
-  it('should fail when using invalid JSDoc comments (matchDescription: "regex", requireReturn: false)', function testInvalidNoRequireReturnAndMatchDescription() {
-    makeTest(rule, scripts.invalidNoRequireReturnAndMatchDescription, false, {
-      rules: {
-        [rule]: [true, {
-          requireReturn: false,
-          matchDescription: MATCH_DESCRIPTION_TEST
-        }]
-      }
-    });
-  });
-});
+ruleTester.runTests();

--- a/src/test/rules/validTypeofRuleTests.ts
+++ b/src/test/rules/validTypeofRuleTests.ts
@@ -1,29 +1,28 @@
-/// <reference path='../../../typings/mocha/mocha.d.ts' />
-import { makeTest } from './helper';
+import { RuleTester, Position, Failure } from './ruleTester';
 
-const rule = 'valid-typeof';
-const scripts = {
-  valid: [
-    'if (typeof foo === "string") {}',
-    'if (typeof bar == \'undefined\') {}',
-    'if (typeof foo === baz) {}',
-    'if (typeof bar === typeof qux) {}'
-  ],
+const ruleTester = new RuleTester('valid-typeof');
 
-  invalid: [
-    'if (typeof foo === "strnig") {}',
-    'if (typeof foo == "undefimed") {}',
-    'if (typeof bar != \'nunber\') {}',
-    'if (typeof bar !== "fucntion") {}'
-  ]
-};
+// There is only one message, checking start and end
+function expecting(errors: [number, number]): Failure[] {
+  return [{
+    failure: 'invalid typeof comparison value',
+    startPosition: new Position(0, errors[0]),
+    endPosition: new Position(0, errors[1])
+  }];
+}
 
-describe(rule, function test() {
-  it('should pass when using valid strings or variables', function testValid() {
-    makeTest(rule, scripts.valid, true);
-  });
+ruleTester.addTestGroup('valid', 'should pass when using valid strings or variables', [
+  'if (typeof foo === "string") {}',
+  'if (typeof bar == \'undefined\') {}',
+  'if (typeof foo === baz) {}',
+  'if (typeof bar === typeof qux) {}'
+]);
 
-  it('should fail when using invalid strings', function testInvalid() {
-    makeTest(rule, scripts.invalid, false);
-  });
-});
+ruleTester.addTestGroup('invalid', 'should fail when using invalid strings', [
+  { code: 'if (typeof foo === "strnig") {}', errors: expecting([4, 14]) },
+  { code: 'if (typeof fooz == "undefimed") {}', errors: expecting([4, 15]) },
+  { code: 'if (typeof bar != \'nunber\') {}', errors: expecting([4, 14]) },
+  { code: 'if (typeof barz !== "fucntion") {}', errors: expecting([4, 15]) }
+]);
+
+ruleTester.runTests();


### PR DESCRIPTION
I have updated some rule tests to use the ruleTester. This will allow us to add more tests and modify the rules by making sure that we are obtaining the correct error messages and positions.

There remains about 10 rules to migrate to using the ruleTester.