### PR TITLE
Fix bug in single type imports (Closes #201)

### DIFF
--- a/src/rules/sortImportsRule.ts
+++ b/src/rules/sortImportsRule.ts
@@ -181,7 +181,7 @@ class RuleWalker extends Lint.RuleWalker {
         sortValue: aliasMatch[1]
       };
     } else {
-      const singleMatch = /\bimport\s+({?([^,{}\*]+?)}?)\s*from\s+[\'"](?:[^"\']+)["\']/g.exec(nodeText);
+      const singleMatch = /\bimport\s+(?:{?([^,{}\*]+?)}?)\s*from\s+[\'"](?:[^"\']+)["\']/g.exec(nodeText);
       const multipleMatch = /\bimport\s*{?\s*([^{}\'",]+?)\s*,(?:\s*.+\s*,\s*)*\s*.+\s*}?\s*from\s+[\'"](?:[^"\']+)["\']/g.exec(nodeText);
       const noneMatch = /\bimport\s+[\'"]([^"\']+)["\']/g.exec(nodeText);
       const allMatch = /\bimport\s+\*\s+as\s+(.+)\s+from\s+[\'"](?:[^"\']+)["\']/g.exec(nodeText);

--- a/src/test/rules/sortImportsRuleTests.ts
+++ b/src/test/rules/sortImportsRuleTests.ts
@@ -207,4 +207,23 @@ ruleTester.addTestGroup('alias', 'should pass alias tests', [
   }
 ]);
 
+ruleTester.addTestGroup('substring', 'imports that are a subset of other imports should come first', [
+  dedent`
+    import {Foo} from 'bar';
+    import {Fooz} from 'buz';`,
+  {
+    code: dedent`
+      import {Fooz} from 'buz';,
+      import {Foo} from 'bar';
+      `,
+    errors: expecting([[ALPHA_ORDER_ERROR('Foo', 'Fooz'), 2, 0, 24]])
+  },
+  dedent`
+    import 'foo';
+    import 'fooz'`,
+  dedent`
+    import {Foo, Gar} from 'a';
+    import {Fooz, Garz} from 'b';`
+]);
+
 ruleTester.runTests();


### PR DESCRIPTION
I discovered a bug in sorting single imports where one was a substring of the other. e.g.
```typescript
import {Foo} from 'a';
import {Fooz} from 'b'; 
```

Was returning an error. This PR corrects it. I added some more tests to cover other scenarios as well.