### PR TITLE
Remove usage of deprecated tslint features

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "tslint": "^4.5.0"
   },
   "dependencies": {
-    "doctrine": "^0.7.2"
+    "doctrine": "^0.7.2",
+    "tsutils": "^1.4.0"
   }
 }

--- a/src/rules/terMaxLenRule.ts
+++ b/src/rules/terMaxLenRule.ts
@@ -9,6 +9,7 @@
 import * as ts from 'typescript';
 import * as Lint from 'tslint';
 
+import { forEachTokenWithTrivia } from 'tsutils';
 import { IDisabledInterval } from 'tslint/lib/language/rule/rule';
 
 const RULE_NAME = 'ter-max-len';
@@ -249,7 +250,7 @@ interface INode {
   kind: number;
 }
 
-class MaxLenWalker extends Lint.SkippableTokenAwareRuleWalker {
+class MaxLenWalker extends Lint.RuleWalker {
   private ignoredIntervals: IDisabledInterval[] = [];
   private optionsObj: { [key: string]: any } = {};
   private comments: INode[] = [];
@@ -301,25 +302,17 @@ class MaxLenWalker extends Lint.SkippableTokenAwareRuleWalker {
   public visitSourceFile(node: ts.SourceFile) {
     super.visitSourceFile(node);
 
-    Lint.scanAllTokens(ts.createScanner(ts.ScriptTarget.ES5, false, ts.LanguageVariant.Standard, node.text), (scanner: ts.Scanner) => {
-      const token = scanner.getToken();
-      const startPos = scanner.getStartPos();
-      if (this.getSkipEndFromStart(startPos)) {
-        // tokens to skip are places where the scanner gets confused about what the token is, without the proper context
-        // (specifically, regex, identifiers, and templates). So skip those tokens.
-        scanner.setTextPos(this.getSkipEndFromStart(startPos));
-        return;
-      }
-
+    forEachTokenWithTrivia(node, (text, token, range) => {
       if (
         token === ts.SyntaxKind.SingleLineCommentTrivia ||
         token === ts.SyntaxKind.MultiLineCommentTrivia
       ) {
-        this.comments.push(this.getINode(token, scanner.getTokenText(), startPos));
+        this.comments.push(this.getINode(token, text.substring(range.pos, range.end), range.pos));
       } else if (token === ts.SyntaxKind.FirstTemplateToken) {
-        this.templates.push(this.getINode(token, scanner.getTokenText(), startPos));
+        this.templates.push(this.getINode(token, text.substring(range.pos, range.end), range.pos));
       }
     });
+
     // We should have all the ignored intervals, comments, strings, templates, etc...
     // lets find those long lines
     this.findFailures(node);

--- a/src/rules/validJsdocRule.ts
+++ b/src/rules/validJsdocRule.ts
@@ -150,7 +150,7 @@ declare interface IReturnPresent {
   returnPresent: boolean;
 }
 
-class ValidJsdocWalker extends Lint.SkippableTokenAwareRuleWalker {
+class ValidJsdocWalker extends Lint.RuleWalker {
   private fns: Array<IReturnPresent> = [];
 
   protected visitSourceFile(node: ts.SourceFile) {


### PR DESCRIPTION
https://github.com/palantir/tslint/pull/2370 removed the deprecated scanAllTokens and SkippableTokenAwareRuleWalker. That change will be shipped with tslint@5.0.
This PR replaces them with a utility function of `tsutils`.