### PR TITLE
[refactor-tests] reverting changes in favor of using tslint parseConfigFile

### DIFF
--- a/src/test/rules/helper.ts
+++ b/src/test/rules/helper.ts
@@ -12,9 +12,9 @@ const options: Lint.ILinterOptions = {
 /**
  * @deprecated Use ruleTester
  */
-export function testScript(rule: string, scriptText: string, config: Lint.Configuration.IConfigurationFile): boolean {
+export function testScript(rule: string, scriptText: string, config: any): boolean {
   const linter = new Lint.Linter(options);
-  linter.lint(`${rule}.ts`, scriptText, config);
+  linter.lint(`${rule}.ts`, scriptText, Lint.Configuration.parseConfigFile(config));
 
   const failures = JSON.parse(linter.getResult().output);
 
@@ -24,16 +24,13 @@ export function testScript(rule: string, scriptText: string, config: Lint.Config
 /**
  * @deprecated Use ruleTester
  */
-export function makeTest(rule: string, scripts: Array<string>, expected: boolean, config?: Lint.Configuration.IConfigurationFile) {
+export function makeTest(rule: string, scripts: Array<string>, expected: boolean, config?: { rules: {} }) {
   if (!config) {
     config = {
-      rulesDirectory: [],
-      rules: new Map<string, Partial<Lint.IOptions>>([
-        [rule, true]
-      ]),
-      extends: [],
-      jsRules: new Map<string, Partial<Lint.IOptions>>()
+      rules: {}
     };
+
+    config.rules[rule] = true;
   }
 
   scripts.forEach((code) => {

--- a/src/test/rules/noConstantConditionRuleTests.ts
+++ b/src/test/rules/noConstantConditionRuleTests.ts
@@ -1,6 +1,5 @@
 /// <reference path='../../../typings/mocha/mocha.d.ts' />
 import { makeTest } from './helper';
-import { IOptions } from 'tslint';
 
 const rule = 'no-constant-condition';
 const scripts = {
@@ -217,14 +216,8 @@ describe(rule, function test() {
   });
 
   it('should pass for literals in loops when checkLoops is false', function testCheckLoopsFalse() {
-    // TODO: This configuration will go away once we start using the ruleTester
     const config = {
-      rules: new Map<string, Partial<IOptions>>([
-        ['no-constant-condition', { ruleArguments: [{ checkLoops: false }] }]
-      ]),
-      rulesDirectory: [],
-      extends: [],
-      jsRules: new Map<string, Partial<IOptions>>()
+      rules: { 'no-constant-condition': [true, { checkLoops: false }] }
     };
 
     makeTest(rule, scripts.forLiterals, true, config);

--- a/src/test/rules/ruleTester.ts
+++ b/src/test/rules/ruleTester.ts
@@ -250,29 +250,21 @@ class TestGroup {
     this.ruleName = ruleName;
     this.description = description;
     this.tests = tests.map((test: ITest | string, index) => {
-      const config: Lint.Configuration.IConfigurationFile = {
-        rules: new Map<string, Partial<Lint.IOptions>>([
-          [ruleName, true]
-        ]),
-        jsRules: new Map<string, Partial<Lint.IOptions>>(),
-        rulesDirectory: ['dist/rules/'],
-        extends: []
-      };
+      const config: any = { rules: { [ruleName]: true } };
       const codeFileName = `${name}-${index}.ts`;
       if (typeof test === 'string') {
         if (groupConfig) {
-          const ruleArgs = Array.isArray(groupConfig) ? groupConfig : [groupConfig];
-          config.rules.set(ruleName, { ruleArguments: ruleArgs });
+          config.rules[ruleName] = [true, ...groupConfig];
         }
-        return new Test(codeFileName, test, undefined, config, []);
+        const configFile = Lint.Configuration.parseConfigFile(config);
+        return new Test(codeFileName, test, undefined, configFile, []);
       }
       if (test.options) {
-        const ruleArgs = Array.isArray(test.options) ? test.options : [test.options];
-        config.rules.set(ruleName, { ruleArguments: ruleArgs });
+        config.rules[ruleName] = [true, ...test.options];
       } else if (groupConfig) {
-        const ruleArgs = Array.isArray(groupConfig) ? groupConfig : [groupConfig];
-        config.rules.set(ruleName, { ruleArguments: ruleArgs });
+        config.rules[ruleName] = [true, ...groupConfig];
       }
+      const configFile = Lint.Configuration.parseConfigFile(config);
       const failures: LintFailure[] = (test.errors || []).map((error) => {
         return new LintFailure(
           codeFileName,
@@ -282,7 +274,7 @@ class TestGroup {
           error.endPosition
         );
       });
-      return new Test(codeFileName, test.code, test.output, config, failures, testFixer);
+      return new Test(codeFileName, test.code, test.output, configFile, failures, testFixer);
     });
   }
 }


### PR DESCRIPTION
Upon close inspection on their source code I found out that each
tslint.json raw contents go through the `parseConfigFile` function. The
changes I had made were a very hacky (and ugly) way of creating a
configuration file. This brings us back to the original code and all
tests seem to pass. There is no rush in creating a release for this
since this is for our internal tests.