### PR TITLE
Avoid module resolution for rules directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 // unopinionated extensable tslint configuration
 // loads rules for extending packages, but does not enable any
 module.exports = {
-    rulesDirectory: "dist/rules",
+    rulesDirectory: "./dist/rules",
 };

--- a/tslint_eslint_rules.json
+++ b/tslint_eslint_rules.json
@@ -1,5 +1,5 @@
 {
-  "rulesDirectory": "dist/rules",
+  "rulesDirectory": "./dist/rules",
   "rules": {
     "no-irregular-whitespace": true,
     "ter-arrow-body-style": [true, "as-needed", {


### PR DESCRIPTION
tslint recently (today) added the ability to specify installed packages as `rulesDirectory`. To avoid this unnecessary module resolution, this PR makes `rulesDirectory` a relative path.