### PR TITLE
[bug] fixed valid-jsdoc rule (closes #220)

### DIFF
--- a/src/rules/validJsdocRule.ts
+++ b/src/rules/validJsdocRule.ts
@@ -261,10 +261,11 @@ class ValidJsdocWalker extends Lint.RuleWalker {
     }
 
     let comments = node.getFullText();
-    comments = comments.substring(comments.indexOf('/**'));
+    let offset = comments.indexOf('/**');
+    comments = comments.substring(offset);
     comments = comments.substring(0, comments.indexOf('*/') + 2);
 
-    let start = node.pos;
+    let start = node.pos + offset;
     let width = comments.length;
 
     if (!/^\/\*\*/.test(comments) || !/\*\/$/.test(comments)) {

--- a/src/test/rules/validJsdocRuleTests.ts
+++ b/src/test/rules/validJsdocRuleTests.ts
@@ -718,4 +718,28 @@ ruleTester.addTestGroup('param-type', 'should handle requireParamType option', [
   }
 ]);
 
+ruleTester.addTestGroup('error-location', 'error location should span the comment', [
+  {
+    code: dedent`
+      /**
+       * Class
+       */
+      class Foo {
+
+        /**
+         * Function
+         */
+        public bar(x: any): void {
+        }
+
+      }`,
+    options: { requireReturn: false },
+    errors: [{
+      failure: "missing JSDoc for parameter 'x'",
+      startPosition: new Position(6, 2),
+      endPosition: new Position(8, 5)
+    }]
+  }
+]);
+
 ruleTester.runTests();


### PR DESCRIPTION
The start index of the comment was not taking into account
whitespace before the start of the comment.