### PR TITLE
[docs] update CONTRIBUTING page to state that rules must have ter prefix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,9 @@ the issue easier and quicker.
  * tslint and typescript version.
 
        $ tslint --version
-       4.5.1
+       5.2.0
        $ tsc --version
-       Version 2.2.1
+       Version 2.3.2
 
  * `tslint.json` configuration.
  * typescript code being linted.
@@ -34,12 +34,15 @@ If you are not yet familiar with the way Github works (forking, pull requests, e
 check out this [article about forking](https://help.github.com/articles/fork-a-repo/). To get
 started on a new rule or fix/improve some existing rule you can follow the instructions below.
 
-- Create a branch with the rule name, e.g. `no-if-usage`.
+- Pick the rule name you will be working on and add the `ter` prefix. For instance, if you will be
+  working on the `no-tabs` rule, then the rule name will be `ter-no-tabs`. This is to avoid future
+  name collision with native rules provided by `TSLint`.
+- Create a branch with the rule name, e.g. `ter-indent`.
 - If you haven't, run `npm install` to download the project dependencies.
 - Create your rule tests at `./src/test/rules` and your rule in `./src/rules` with the convention:
-  - Name: rule-name (hyphenated, e.g: no-if-usage)
-  - Rule File: ruleNameRule.ts (camelCased and with the `Rule` suffix, e.g: noIfUsageRule.ts)
-  - Test File: ruleNameRuleTests.ts (camelCased and with the `RuleTests` suffix, e.g: noIfUsageRuleTests.ts)
+  - Name: rule-name (hyphenated, e.g: `ter-no-if-usage`)
+  - Rule File: ruleNameRule.ts (camelCased and with the `Rule` suffix, e.g: `terNoIfUsageRule.ts`)
+  - Test File: ruleNameRuleTests.ts (camelCased and with the `RuleTests` suffix, e.g: `terNoIfUsageRuleTests.ts`)
 
   This step can be done automatically by running
 
@@ -47,9 +50,9 @@ started on a new rule or fix/improve some existing rule you can follow the instr
   gulp new-rule --rule rule-name
   ```
 
-  This will generate a the rule template and test template in the appropiate directories.
+  This will generate a the rule template and test template in the appropriate directories.
 
-- Check if your rule is passing with `gulp test --single rule-name` (hyphenated, e.g no-inner-declarations)
+- Check if your rule is passing with `gulp test --single rule-name` (hyphenated, e.g ter-arrow-spacing)
   - During development you may have some linting errors that won't let you run the test. You can
     disable the linting process with the `--no-lint` flag: `gulp test --single rule-name --no-lint`.
   - If you are using the `RuleTester` utility as in the `ter-indent` rule tests you can specify a

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,12 +38,15 @@ gulp.task('fetch', ['build'], function fetch(gulpCallBack) {
 
 gulp.task('new-rule', ['build'], function newRule(done) {
   var newRule = require('./dist/tools/newRule');
-  if (argv.rule) {
-    newRule.writeNewRule(argv.rule);
-    newRule.writeNewRuleTests(argv.rule);
-    done();
-  } else {
+  const ruleName = argv.rule;
+  if (!ruleName) {
     done('missing `--rule` option');
+  } else if (!ruleName.startsWith('ter-')) {
+    done('rule name is missing the `ter-` prefix');
+  } else {
+    newRule.writeNewRule(ruleName);
+    newRule.writeNewRuleTests(ruleName);
+    done();
   }
 });
 

--- a/src/readme/rules.ts
+++ b/src/readme/rules.ts
@@ -3101,9 +3101,11 @@ const rules: IRule[] = [
   }
 ];
 
-function toCamelCase(str: string): string {
+function toCamelCase(str: string, pascal: boolean = false): string {
   const words = str.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1));
-  words[0] = words[0].toLowerCase();
+  if (!pascal) {
+    words[0] = words[0].toLowerCase();
+  }
   return words.join('');
 }
 

--- a/src/tools/newRule.ts
+++ b/src/tools/newRule.ts
@@ -4,10 +4,14 @@ import * as path from 'path';
 
 export function writeNewRule(ruleKebabName: string): void {
   const ruleCamelName = toCamelCase(ruleKebabName);
+  const ruleOptionsName = `I${toCamelCase(ruleKebabName, true)}Options`;
   const ruleTemplate = `import * as ts from 'typescript';
 import * as Lint from 'tslint';
 
 const RULE_NAME = '${ruleKebabName}';
+interface ${ruleOptionsName} {
+  // Add the options properties
+}
 
 export class Rule extends Lint.Rules.AbstractRule {
   public static metadata: Lint.IRuleMetadata = {
@@ -41,14 +45,23 @@ export class Rule extends Lint.Rules.AbstractRule {
     type: ''  // one of "functionality" | "maintainability" | "style" | "typescript"
   };
 
+  private formatOptions(ruleArguments: any[]): ${ruleOptionsName} {
+    // handle the ruleArguments
+    return {};
+  }
+
   public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-    const walker = new RuleWalker(sourceFile, this.getOptions());
+    // Convert the 'ruleArguments' into a useful format before passing it to the constructor of AbstractWalker.
+    const opt = this.formatOptions(this.ruleArguments);
+    const walker = new RuleWalker(sourceFile, this.ruleName, opt);
     return this.applyWithWalker(walker);
   }
 }
 
-class RuleWalker extends Lint.RuleWalker {
-  // ** RULE IMPLEMENTATION HERE **
+// NOTE: please remove this comment after reading: https://palantir.github.io/tslint/develop/custom-rules/walker-design.html
+class RuleWalker extends Lint.AbstractWalker<${ruleOptionsName}> {
+  public walk(sourceFile: ts.SourceFile) {
+  }
 }
 `;
   const projectDir = path.dirname(__dirname);
@@ -62,13 +75,15 @@ export function writeNewRuleTests(ruleKebabName: string): void {
 
 const ruleTester = new RuleTester('${ruleKebabName}');
 
-function expecting(errors: string[]]): Failure[] {
+// Change this function to better test the rule. In some cases the message never changes so we
+// can avoid passing it in. See other rule tests for examples.
+function expecting(errors: [string, number, number][]): Failure[] {
   return errors.map((err) => {
-    let message = '';
+    let message = err[0];
     return {
       failure: message,
-      startPosition: new Position(err[0]),
-      endPosition: new Position()
+      startPosition: new Position(err[1]),
+      endPosition: new Position(err[2])
     };
   });
 }


### PR DESCRIPTION
`new-rule` gulp task has been updated to make sure we add the ter
prefix. The templates have also been updated and link to tslint has
been added to point developers on how to design rule walkers.