### PR TITLE
[feat] Implementing ter-computed-property-spacing rule

### DIFF
--- a/src/docs/rules/terComputedPropertySpacingRule.md
+++ b/src/docs/rules/terComputedPropertySpacingRule.md
@@ -1,0 +1,48 @@
+<!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
+## ter-computed-property-spacing (ESLint: [computed-property-spacing](http://eslint.org/docs/rules/computed-property-spacing))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/terComputedPropertySpacingRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/terComputedPropertySpacingRuleTests.ts)
+
+require or disallow padding inside computed properties
+
+#### Rationale
+
+While formatting preferences are very personal, a number of style guides require or disallow spaces between computed properties in the following situations:
+    
+### Config
+
+The rule takes in one option, which defines to require or forbid whitespace.
+
+* `"never"` (default) disallows spaces inside computed property brackets
+* `"always"` requires one or more spaces inside computed property brackets
+    
+#### Examples
+
+```json
+"ter-computed-property-spacing": [true]
+```
+
+```json
+"ter-computed-property-spacing": [true, "always"]
+      ```
+
+```json
+"ter-computed-property-spacing": [true, "never"]
+      ```
+#### Schema
+
+```json
+{
+  "type": "array",
+  "items": [
+    {
+      "enum": [
+        "always",
+        "never"
+      ]
+    }
+  ],
+  "maxLength": 1
+}
+```
+<!-- End:AutoDoc -->

--- a/src/readme/rules.ts
+++ b/src/readme/rules.ts
@@ -1652,9 +1652,9 @@ const rules: IRule[] = [
     ~~~`
   },
   {
-    available: false,
+    available: true,
     eslintRule: 'computed-property-spacing',
-    tslintRule: 'computed-property-spacing',
+    tslintRule: 'ter-computed-property-spacing',
     category: 'Stylistic Issues',
     description: 'require or disallow padding inside computed properties',
     eslintUrl: 'http://eslint.org/docs/rules/computed-property-spacing',

--- a/src/rules/terComputedPropertySpacingRule.ts
+++ b/src/rules/terComputedPropertySpacingRule.ts
@@ -1,0 +1,148 @@
+import * as ts from 'typescript';
+import * as Lint from 'tslint';
+
+const RULE_NAME = 'ter-computed-property-spacing';
+interface ITerComputedPropertySpacingOptions {
+  always: boolean;
+}
+
+const ALWAYS_BEFORE_MESSAGE = "A space is required before ']'.";
+const ALWAYS_AFTER_MESSAGE = "A space is required after '['.";
+const NEVER_BEFORE_MESSAGE = "There should be no space before ']'.";
+const NEVER_AFTER_MESSAGE = "There should be no space after '['.";
+
+export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: RULE_NAME,
+    hasFix: true,
+    description: 'require or disallow padding inside computed properties',
+    rationale: Lint.Utils.dedent`
+      While formatting preferences are very personal, a number of style guides require or disallow spaces between computed properties in the following situations:
+    `,
+    optionsDescription: Lint.Utils.dedent`
+      The rule takes in one option, which defines to require or forbid whitespace.
+
+      * \`"never"\` (default) disallows spaces inside computed property brackets
+      * \`"always"\` requires one or more spaces inside computed property brackets
+    `,
+    options: {
+      type: 'array',
+      items: [{
+        enum: [ 'always', 'never' ]
+      }],
+      maxLength: 1
+    },
+    optionExamples: [
+      Lint.Utils.dedent`
+        "${RULE_NAME}": [true]
+        `,
+      Lint.Utils.dedent`
+        "${RULE_NAME}": [true, "always"]
+      `,
+      Lint.Utils.dedent`
+        "${RULE_NAME}": [true, "never"]
+      `
+    ],
+    typescriptOnly: false,
+    type: 'style'
+  };
+
+  private formatOptions([ alwaysOrNever ]: string[]): ITerComputedPropertySpacingOptions {
+    // handle the ruleArguments
+    return {
+      always: alwaysOrNever === 'always'
+    };
+  }
+
+  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    const opt = this.formatOptions(this.ruleArguments);
+    const walker = new RuleWalker(sourceFile, this.ruleName, opt);
+    return this.applyWithWalker(walker);
+  }
+}
+
+class RuleWalker extends Lint.AbstractWalker<ITerComputedPropertySpacingOptions> {
+  public walk(sourceFile: ts.SourceFile) {
+    const cb = (node: ts.Node): void => {
+      if (node.kind === ts.SyntaxKind.ElementAccessExpression) {
+        this.checkNode(
+          node,
+          node.getChildAt(1),
+          node.getChildAt(3)
+        );
+      } else if (node.kind === ts.SyntaxKind.ComputedPropertyName) {
+        this.checkNode(
+          node,
+          node.getChildAt(0),
+          node.getChildAt(2)
+        );
+      }
+
+      ts.forEachChild(node, cb);
+    };
+
+    ts.forEachChild(sourceFile, cb);
+  }
+
+  private checkNode(node: ts.Node, leftBracketNode: ts.Node, rightBracketNode: ts.Node): void {
+    const nodeText = node.getText();
+
+    const regex = /\[([\s\S]*)\]/;
+
+    const match = regex.exec(nodeText);
+
+    if (!match) {
+      return;
+    }
+
+    const contentWithinBrackets = match[1];
+
+    if (this.options.always) {
+      const beforeWhitespaceLength = this.getBeforeWhitespaceLength(contentWithinBrackets, true);
+      const afterWhitespaceLength = this.getAfterWhitespaceLength(contentWithinBrackets, true);
+
+      if (beforeWhitespaceLength === 0) {
+        this.addFailureAtNode(leftBracketNode, ALWAYS_AFTER_MESSAGE, Lint.Replacement.appendText(leftBracketNode.getEnd(), ' '));
+      }
+
+      if (afterWhitespaceLength === 0) {
+        this.addFailureAtNode(rightBracketNode, ALWAYS_BEFORE_MESSAGE, Lint.Replacement.appendText(rightBracketNode.getStart(), ' '));
+      }
+    } else {
+      // Newlines don't count as whitespace
+      const contentWithinBracketsNoNewlines = contentWithinBrackets.replace('\n', '');
+      const beforeWhitespaceLength = this.getBeforeWhitespaceLength(contentWithinBracketsNoNewlines, false);
+      const afterWhitespaceLength = this.getAfterWhitespaceLength(contentWithinBracketsNoNewlines, false);
+
+      if (beforeWhitespaceLength !== 0) {
+        this.addFailureAtNode(leftBracketNode, NEVER_AFTER_MESSAGE, Lint.Replacement.deleteText(leftBracketNode.getEnd(), beforeWhitespaceLength));
+      }
+
+      if (afterWhitespaceLength !== 0) {
+        this.addFailureAtNode(rightBracketNode, NEVER_BEFORE_MESSAGE, Lint.Replacement.deleteText(rightBracketNode.getStart() - afterWhitespaceLength, afterWhitespaceLength));
+      }
+    }
+  }
+
+  private getBeforeWhitespaceLength(content: string, newlinesCountAsWhitespace: boolean): number {
+    const regex = newlinesCountAsWhitespace ? /^\s+/ : /^[^\S\n]+/;
+    const match = regex.exec(content);
+
+    if (match) {
+      return match[0].length;
+    } else {
+      return 0;
+    }
+  }
+
+  private getAfterWhitespaceLength(content: string, newlinesCountAsWhitespace: boolean): number {
+    const regex = newlinesCountAsWhitespace ? /\s+$/ : /[^\S\n]+$/;
+    const match = regex.exec(content);
+
+    if (match) {
+      return match[0].length;
+    } else {
+      return 0;
+    }
+  }
+}

--- a/src/test/rules/terComputedPropertySpacingRuleTests.ts
+++ b/src/test/rules/terComputedPropertySpacingRuleTests.ts
@@ -1,0 +1,212 @@
+import { RuleTester, Failure, Position } from './ruleTester';
+
+const ruleTester = new RuleTester('ter-computed-property-spacing', true);
+
+function expecting(errors: ['yesBefore' | 'yesAfter' | 'noBefore' | 'noAfter', number ][]): Failure[] {
+  const errorMessages = {
+    yesBefore: "A space is required before ']'.",
+    yesAfter: "A space is required after '['.",
+    noBefore: "There should be no space before ']'.",
+    noAfter: "There should be no space after '['."
+  };
+
+  return errors.map((err) => {
+    const message = errorMessages[err[0]];
+
+    return {
+      failure: message,
+      startPosition: new Position(0, err[1]),
+      endPosition: new Position(0, err[1] + 1)
+    };
+  });
+}
+
+ruleTester.addTestGroup('default-never-valid', 'default is never', [
+  { code: 'obj[foo]' },
+  { code: "obj['foo']" },
+  { code: 'var x = {[b]: a}' }
+]);
+
+ruleTester.addTestGroup('always-valid', 'when always, spaces are required', [
+  { code: 'obj[ foo ]', options: ['always'] },
+  { code: 'obj[\nfoo\n]', options: ['always'] },
+  { code: "obj[ 'foo' ]", options: ['always'] },
+  { code: "obj[ 'foo' + 'bar' ]", options: ['always'] },
+  { code: 'obj[ obj2[ foo ] ]', options: ['always'] },
+  { code: 'obj.map(function(item) { return [\n1,\n2,\n3,\n4\n]; })', options: ['always'] },
+  { code: "obj[ 'map' ](function(item) { return [\n1,\n2,\n3,\n4\n]; })", options: ['always'] },
+  { code: "obj[ 'for' + 'Each' ](function(item) { return [\n1,\n2,\n3,\n4\n]; })", options: ['always'] },
+  { code: 'obj[ obj2[ foo ] ]', options: ['always'] },
+  { code: 'var foo = obj[ 1 ]', options: ['always'] },
+  { code: "var foo = obj[ 'foo' ];", options: ['always'] },
+  { code: 'var foo = obj[ [1, 1] ];', options: ['always'] }
+]);
+
+ruleTester.addTestGroup('always-valid-objectLiteralComputedProperties', 'when always, spaces are required inside a computed property name', [
+  { code: 'var x = {[ "a" ]: a}', options: ['always'] },
+  { code: 'var y = {[ x ]: a}', options: ['always'] },
+  { code: 'var x = {[ "a" ]() {}}', options: ['always'] },
+  { code: 'var y = {[ x ]() {}}', options: ['always'] }
+]);
+
+ruleTester.addTestGroup('always-valid-unrelatedCases', "defining an empty object or array doesn't require spaces", [
+  { code: 'var foo = {};', options: ['always'] },
+  { code: 'var foo = [];', options: ['always'] }
+]);
+
+ruleTester.addTestGroup('never-valid', 'when never, accept no spaces', [
+  { code: 'obj[foo]', options: ['never'] },
+  { code: "obj['foo']", options: ['never'] },
+  { code: "obj['foo' + 'bar']", options: ['never'] },
+  { code: "obj['foo'+'bar']", options: ['never'] },
+  { code: 'obj[obj2[foo]]', options: ['never'] },
+  { code: 'obj.map(function(item) { return [\n1,\n2,\n3,\n4\n]; })', options: ['never'] },
+  { code: "obj['map'](function(item) { return [\n1,\n2,\n3,\n4\n]; })", options: ['never'] },
+  { code: "obj['for' + 'Each'](function(item) { return [\n1,\n2,\n3,\n4\n]; })", options: ['never'] },
+  { code: "obj['for' + 'Each'](function(item) { return [\n1,\n2,\n3,\n4\n]; })", options: ['never'] },
+  { code: 'obj[\nfoo]', options: ['never'] },
+  { code: 'obj[foo\n]', options: ['never'] },
+  { code: 'var foo = obj[1]', options: ['never'] },
+  { code: "var foo = obj['foo'];", options: ['never'] },
+  { code: 'var foo = obj[[ 1, 1 ]];', options: ['never'] }
+]);
+
+ruleTester.addTestGroup('never-valid-objectLiteralComputedProperties', 'when never, spaces are forbidden inside a computed property name', [
+  { code: 'var x = {["a"]: a}', options: ['never'] },
+  { code: 'var y = {[x]: a}', options: ['never'] },
+  { code: 'var x = {["a"]() {}}', options: ['never'] },
+  { code: 'var y = {[x]() {}}', options: ['never'] }
+]);
+
+ruleTester.addTestGroup('never-valid-unrelatedCases', "defining an empty object or array doesn't require spaces", [
+  { code: 'var foo = {};', options: ['never'] },
+  { code: 'var foo = [];', options: ['never'] }
+]);
+
+ruleTester.addTestGroup('always-invalid', 'when always, no spaces are forbidden', [
+  {
+    code: 'var foo = obj[ 1];',
+    output: 'var foo = obj[ 1 ];',
+    options: ['always'],
+    errors: expecting([[ 'yesBefore', 16 ]])
+  },
+  {
+    code: 'var foo = obj[1 ];',
+    output: 'var foo = obj[ 1 ];',
+    options: ['always'],
+    errors: expecting([[ 'yesAfter', 13 ]])
+  },
+  {
+    code: 'var foo = obj[ 1];',
+    output: 'var foo = obj[ 1 ];',
+    options: ['always'],
+    errors: expecting([[ 'yesBefore', 16 ]])
+  },
+  {
+    code: 'var foo = obj[1 ];',
+    output: 'var foo = obj[ 1 ];',
+    options: ['always'],
+    errors: expecting([[ 'yesAfter', 13 ]])
+  },
+  {
+    code: 'var foo = obj[1]',
+    output: 'var foo = obj[ 1 ]',
+    options: ['always'],
+    errors: expecting([
+      [ 'yesAfter', 13 ],
+      [ 'yesBefore', 15 ]
+    ])
+  }
+]);
+
+ruleTester.addTestGroup('never-invalid', 'when never, spaces are prohibited', [
+  {
+    code: 'var foo = obj[ 1];',
+    output: 'var foo = obj[1];',
+    options: ['never'],
+    errors: expecting([[ 'noAfter', 13 ]])
+  },
+  {
+    code: 'var foo = obj[1 ];',
+    output: 'var foo = obj[1];',
+    options: ['never'],
+    errors: expecting([[ 'noBefore', 16 ]])
+  },
+  {
+    code: 'obj[ foo ]',
+    output: 'obj[foo]',
+    options: ['never'],
+    errors: expecting([
+      [ 'noAfter', 3 ],
+      [ 'noBefore', 9 ]
+    ])
+  },
+  {
+    code: 'obj[foo ]',
+    output: 'obj[foo]',
+    options: ['never'],
+    errors: expecting([[ 'noBefore', 8 ]])
+  },
+  {
+    code: 'obj[ foo]',
+    output: 'obj[foo]',
+    options: ['never'],
+    errors: expecting([[ 'noAfter', 3 ]])
+  }
+]);
+
+ruleTester.addTestGroup('always-invalid-objectLiteralComputedProperties', 'when always, space is required inside object literal computed properties', [
+  {
+    code: 'var x = {[a]: b}',
+    output: 'var x = {[ a ]: b}',
+    options: ['always'],
+    errors: expecting([
+      [ 'yesAfter', 9 ],
+      [ 'yesBefore', 11 ]
+    ])
+  },
+  {
+    code: 'var x = {[a ]: b}',
+    output: 'var x = {[ a ]: b}',
+    options: ['always'],
+    errors: expecting([[ 'yesAfter', 9 ]])
+  },
+  {
+    code: 'var x = {[ a]: b}',
+    output: 'var x = {[ a ]: b}',
+    options: ['always'],
+    errors: expecting([[ 'yesBefore', 12 ]])
+  }
+]);
+
+ruleTester.addTestGroup('never-invalid-objectLiteralComputedProperties', 'when never, spaces prohibited inside object literal computed properties', [
+  {
+    code: 'var x = {[ a ]: b}',
+    output: 'var x = {[a]: b}',
+    options: ['never'],
+    errors: expecting([
+      [ 'noAfter', 9 ],
+      [ 'noBefore', 13 ]
+    ])
+  },
+  {
+    code: 'var x = {[a ]: b}',
+    output: 'var x = {[a]: b}',
+    options: ['never'],
+    errors: expecting([[ 'noBefore', 12 ]])
+  },
+  {
+    code: 'var x = {[ a]: b}',
+    output: 'var x = {[a]: b}',
+    options: ['never'],
+    errors: expecting([[ 'noAfter', 9 ]])
+  },
+  {
+    code: 'var x = {[ a\n]: b}',
+    output: 'var x = {[a\n]: b}',
+    options: ['never'],
+    errors: expecting([[ 'noAfter', 9 ]])
+  }
+]);
+
+ruleTester.runTests();


### PR DESCRIPTION
Adding the `ter-computed-property-spacing` rule, which implements `computed-property-spacing` from eslint.

http://eslint.org/docs/rules/computed-property-spacing

See also #172 