### PR TITLE
[bug] fix null warning in valid-jsdoc

### DIFF
--- a/src/rules/validJsdocRule.ts
+++ b/src/rules/validJsdocRule.ts
@@ -339,7 +339,7 @@ class ValidJsdocWalker extends Lint.RuleWalker {
 
           isAbstract = Lint.hasModifier(fn.node.modifiers, ts.SyntaxKind.AbstractKeyword);
 
-          if (!isAbstract && !OPTIONS.requireReturn && !fn.returnPresent && tag.type.name !== 'void' && tag.type.name !== 'undefined') {
+          if (!isAbstract && !OPTIONS.requireReturn && !fn.returnPresent && tag.type && tag.type.name !== 'void' && tag.type.name !== 'undefined') {
             this.addFailure(this.createFailure(start, width, Rule.FAILURE_STRING.unexpectedTag(tag.title)));
           }
           else {

--- a/src/test/rules/validJsdocRuleTests.ts
+++ b/src/test/rules/validJsdocRuleTests.ts
@@ -692,6 +692,28 @@ ruleTester.addTestGroup('issue178', 'issue 178 - Should not crash with incorrect
   }
 ]);
 
+ruleTester.addTestGroupWithConfig(
+  'issue238',
+  "issue 238 - Cannot read property 'name' of null",
+  {
+    requireReturn: false,
+    requireReturnType: false
+  },
+  [
+    {
+      code: dedent`
+        class MyPage {
+          /**
+           * Navigate to the page
+           * @returns a promise for the browser's navigation
+           */
+          public async navigateTo() { }
+        }
+        `
+    }
+  ]
+);
+
 ruleTester.addTestGroup('ret-type', 'should handle requireReturnType option', [
   {
     code: dedent`


### PR DESCRIPTION
Closes #238 

This fixes the issue, and adds a test for it. The only problem is, the test suite won't actually fail on warnings. It displays the warning, but it won't fail:

![image](https://user-images.githubusercontent.com/1757708/27478975-b15f1a8a-5809-11e7-995f-fdd9da53f339.png)

Let me know if there is anything I must do to make the test suite fail on the warning.