### PR TITLE
[bug] valid-jsdoc does not require @returns on void or never functions (closes #234)

### DIFF
--- a/src/test/rules/validJsdocRuleTests.ts
+++ b/src/test/rules/validJsdocRuleTests.ts
@@ -784,4 +784,151 @@ ruleTester.addTestGroup('error-location', 'error location should span the commen
   }
 ]);
 
+ruleTester.addTestGroup('never-or-void-return-type', 'functions that return "never" or "void" should not require @returns', [
+  {
+    code: dedent`
+      /**
+       * Has void return type.
+       */
+      function throwError(): void {
+        throw new Error('Foo');
+      }
+      `,
+    options: { requireReturn: false },
+    errors: []
+  },
+  {
+    code: dedent`
+      /**
+       * Has never return type.
+       */
+      function throwError(): never {
+        throw new Error('Foo');
+      }
+      `,
+    options: { requireReturn: false },
+    errors: []
+  },
+  {
+    code: dedent`
+      /**
+       * Returns result of never function, is void type, and does not have returns tag.
+       */
+      function callInfinite(): void {
+        return neverReturn();
+      }
+
+      /**
+       * Has never return type.
+       */
+      function neverReturn(): never {
+        while (true) {};
+      }
+      `,
+    options: { requireReturn: false },
+    errors: []
+  },
+  {
+    code: dedent`
+      /**
+       * Returns result of never function, is never type, and does not have returns tag.
+       */
+      function callInfinite(): never {
+        return neverReturn();
+      }
+
+      /**
+       * Has never return type.
+       */
+      function neverReturn(): never {
+        while (true) {};
+      }
+      `,
+    options: { requireReturn: false },
+    errors: []
+  },
+  {
+    code: dedent`
+      /**
+       * Returns result of never function, is void type, but has returns tag.
+       * @returns something
+       */
+      function callInfinite(): void {
+        return neverReturn();
+      }
+
+      /**
+       * Has never return type.
+       */
+      function neverReturn(): never {
+        while (true) {};
+      }
+      `,
+    options: { requireReturn: false, requireReturnType: false },
+    errors: []
+  },
+  {
+    code: dedent`
+      /**
+       * Returns result of never function, is never type, but has returns tag.
+       * @returns something
+       */
+      function callInfinite(): never {
+        return neverReturn();
+      }
+
+      /**
+       * Has never return type.
+       */
+      function neverReturn(): never {
+        while (true) {};
+      }
+      `,
+    options: { requireReturn: false, requireReturnType: false },
+    errors: []
+  },
+  {
+    code: dedent`
+      /**
+       * Is void type, but requires returns tag.
+       * @returns something
+       */
+      function callInfinite(): void {
+        return neverReturn();
+      }
+
+      /**
+       * Has never return type.
+       * @returns something
+       */
+      function neverReturn(): never {
+        while (true) {};
+      }
+      `,
+    options: { requireReturn: true, requireReturnType: false },
+    errors: []
+  },
+  {
+    code: dedent`
+      /**
+       * Is never type, but requires returns tag.
+       * @returns something
+       */
+      function callInfinite(): never {
+        return neverReturn();
+      }
+
+      /**
+       * Has never return type.
+       * @returns something
+       */
+      function neverReturn(): never {
+        while (true) {};
+      }
+      `,
+    options: { requireReturn: true, requireReturnType: false },
+    errors: []
+  }
+]);
+
 ruleTester.runTests();


### PR DESCRIPTION
Closes #234.

If a function is declared to have a return type of `void` or `never`, but had a return statement with an expression, the `valid-jsdoc` rule was expecting to find an `@returns` tag in the comments. In the case of `void` and `never` functions, they can't return anything, and the return statement was just a way of calling a function and exiting in the one statement.

The change I've made checks if the function has a declared type, and if that declared type is `void` or `never`, then an `@returns` tag is not required (but is allowed to exist). If the function doesn't have a declared type, or it's not `void` or `never`, then the rule operates exactly as it did before.