### PR TITLE
[feat] added ter-no-tabs rule (closes #215)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,9 @@
 {
   "editor.insertSpaces": true,
   "editor.tabSize": 2,
+  "tslint.configFile": "tslint.json",
   "tslint.enable": true,
+  "tslint.rulesDirectory": "node_modules/tslint-eslint-rules/dist/rules",
   "files.eol": "\n",
-  "tslint.options": {
-    "rulesDirectory": "node_modules/tslint-eslint-rules/dist/rules"
-  },
   "files.insertFinalNewline": true
 }

--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ These rules are purely matters of style and are quite subjective.
 |:x:|[space-unary-ops](http://eslint.org/docs/rules/space-unary-ops)|space-unary-ops|require or disallow spaces before/after unary operators|
 |:ballot_box_with_check:|[spaced-comment](http://eslint.org/docs/rules/spaced-comment)|[comment-format](https://palantir.github.io/tslint/rules/comment-format)|require or disallow a space immediately following the `//` or `/*` in a comment|
 |:x:|[wrap-regex](http://eslint.org/docs/rules/wrap-regex)|wrap-regex|require regex literals to be wrapped in parentheses|
+|:white_check_mark:|[no-tabs](https://eslint.org/docs/rules/no-tabs)|[ter-no-tabs](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/docs/rules/terNoTabsRule.md)|disallow all tabs|
 
 ### ECMAScript 6
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1052,7 +1052,7 @@
         "chalk": "1.1.3",
         "deprecated": "0.0.1",
         "gulp-util": "3.0.8",
-        "interpret": "1.0.3",
+        "interpret": "1.0.4",
         "liftoff": "2.3.0",
         "minimist": "1.2.0",
         "orchestrator": "0.3.8",
@@ -1666,9 +1666,9 @@
       "dev": true
     },
     "interpret": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-      "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
+      "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
       "dev": true
     },
     "invert-kv": {
@@ -3246,12 +3246,6 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3262,6 +3256,12 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",

--- a/src/docs/rules/terNoTabsRule.md
+++ b/src/docs/rules/terNoTabsRule.md
@@ -1,0 +1,22 @@
+<!-- Start:AutoDoc:: Modify `src/readme/rules.ts` and run `gulp readme` to update block -->
+## ter-no-tabs (ESLint: [no-tabs](https://eslint.org/docs/rules/no-tabs))
+[![rule_source](https://img.shields.io/badge/%F0%9F%93%8F%20rule-source-green.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/rules/terNoTabsRule.ts)
+[![test_source](https://img.shields.io/badge/%F0%9F%93%98%20test-source-blue.svg)](https://github.com/buzinas/tslint-eslint-rules/blob/master/src/test/rules/terNoTabsRuleTests.ts)
+
+disallow all tabs
+
+#### Rationale
+
+This rule looks for tabs anywhere inside a file: code, comments or anything else, and disallows their usage.
+
+### Config
+
+#### Examples
+
+```json"ter-no-tabs": true```
+#### Schema
+
+```json
+{}
+```
+<!-- End:AutoDoc -->

--- a/src/readme/rules.ts
+++ b/src/readme/rules.ts
@@ -2777,6 +2777,18 @@ const rules: IRule[] = [
   },
   {
     available: true,
+    eslintRule: 'no-tabs',
+    tslintRule: 'ter-no-tabs',
+    category: 'Stylistic Issues',
+    description: 'disallow all tabs',
+    eslintUrl: 'https://eslint.org/docs/rules/no-tabs',
+    provider: 'tslint-eslint-rules',
+    usage: `~~~json
+    "ter-no-tabs": true
+    ~~~`
+  },
+  {
+    available: true,
     eslintRule: 'arrow-body-style',
     tslintRule: 'ter-arrow-body-style',
     category: 'ECMAScript 6',

--- a/src/rules/terNoTabsRule.ts
+++ b/src/rules/terNoTabsRule.ts
@@ -1,0 +1,54 @@
+/**
+ * This rule is a port of eslint:
+ *
+ * source file: https://github.com/eslint/eslint/blob/master/lib/rules/no-tabs.js
+ * git commit hash: 2b1eba221ba7d978c298d0ad7cd4de50f2c796b6
+ *
+ */
+import * as ts from 'typescript';
+import * as Lint from 'tslint';
+
+const RULE_NAME = 'ter-no-tabs';
+interface ITerNoTabsOptions {
+  // Add the options properties
+}
+
+export class Rule extends Lint.Rules.AbstractRule {
+  public static FAILURE_STRING = 'Unexpected tab character.';
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: RULE_NAME,
+    hasFix: false,
+    description: 'disallow all tabs',
+    rationale: Lint.Utils.dedent`
+      This rule looks for tabs anywhere inside a file: code, comments or anything else, and disallows their usage.
+      `,
+    optionsDescription: '',
+    options: {},
+    optionExamples: [Lint.Utils.dedent`"${RULE_NAME}": true`],
+    typescriptOnly: false,
+    type: 'style'
+  };
+
+  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    const walker = new RuleWalker(sourceFile, this.ruleName, {});
+    return this.applyWithWalker(walker);
+  }
+}
+
+class RuleWalker extends Lint.AbstractWalker<ITerNoTabsOptions> {
+  public walk(sourceFile: ts.SourceFile) {
+    const TAB_REGEX = /\t/;
+    const lines = sourceFile.text.split(/\n/g);
+
+    lines.forEach((line, i) => {
+      const match = TAB_REGEX.exec(line);
+      if (match) {
+        this.addFailureAt(
+          sourceFile.getPositionOfLineAndCharacter(i, match.index),
+          1,
+          Rule.FAILURE_STRING
+        );
+      }
+    });
+  }
+}

--- a/src/test/rules/terNoTabsRuleTests.ts
+++ b/src/test/rules/terNoTabsRuleTests.ts
@@ -1,0 +1,56 @@
+import { RuleTester, Failure, Position, dedent } from './ruleTester';
+
+const ruleTester = new RuleTester('ter-no-tabs');
+
+// There is only one message, checking for line and column
+function expecting(errors: [number, number][]): Failure[] {
+  return errors.map((err) => {
+    return {
+      failure: 'Unexpected tab character.',
+      startPosition: new Position(err[0], err[1]),
+      endPosition: new Position()
+    };
+  });
+}
+
+ruleTester.addTestGroup('valid', 'should pass when not using tabs', [
+  'function test(){\n}',
+  dedent`
+  function test(){
+    //   sdfdsf
+  }`
+]);
+
+ruleTester.addTestGroup('invalid', 'should fail when using tabs', [
+  {
+    code: 'function test(){\t}',
+    errors: expecting([[0, 16]])
+  },
+  {
+    code: '/** \t comment test */',
+    errors: expecting([[0, 4]])
+  },
+  {
+    code: dedent`
+    function\t test(){
+      //   sdfdsf
+    }`,
+    errors: expecting([[1, 8]])
+  },
+  {
+    code: dedent`
+    function test(){
+      //   \tsdfdsf
+    }`,
+    errors: expecting([[2, 7]])
+  },
+  {
+    code: dedent`
+    function\t test(){
+      //   \tsdfdsf
+    }`,
+    errors: expecting([[1, 8], [2, 7]])
+  }
+]);
+
+ruleTester.runTests();


### PR DESCRIPTION
Adding `ter-no-tabs` rule, which implements `no-tabs` from ESLint
https://eslint.org/docs/rules/no-tabs

closes #215
part of #251