### PR TITLE
add peer dependency to typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "yargs": "^5.0.0"
   },
   "peerDependencies": {
-    "tslint": "^5.0.0"
+    "tslint": "^5.0.0",
+    "typescript": "^2.2.0"
   },
   "dependencies": {
     "doctrine": "^0.7.2",


### PR DESCRIPTION
The rule .js files require both tslint and typescript.  However, tslint is a peerDependency while typescript is only a devDependency.  I added it as a peer dependency as well (similar to tslint).  

My build system depends on the package.json specifying a dependency if it is used, so while for others this will usually not be a problem I kindly ask you to please merge it in.

