### PR TITLE
[fix] issue with call expressions (closes #254)

### DIFF
--- a/src/rules/terIndentRule.ts
+++ b/src/rules/terIndentRule.ts
@@ -391,7 +391,7 @@ class IndentWalker extends Lint.RuleWalker {
       return this.getNodeIndent(node.parent);
     }
 
-    const endIndex = node.getStart();
+    const endIndex = node.getStart(this.srcFile);
     let pos = endIndex - 1;
     while (pos > 0 && this.srcText.charAt(pos) !== '\n') {
       pos -= 1;
@@ -1159,9 +1159,11 @@ class IndentWalker extends Lint.RuleWalker {
       const indent = this.getLineAndCharacter(node.arguments[0]).character;
       this.checkNodesIndent(node.arguments.slice(1), indent);
     } else if (OPTIONS.CallExpression.arguments !== null) {
+      const openParen = node.getChildAt(node.getChildCount(this.srcFile) - 3, this.srcFile);
+      const openParenIndent = this.getNodeIndent(openParen);
       this.checkNodesIndent(
         node.arguments,
-        this.getNodeIndent(node).goodChar + indentSize * OPTIONS.CallExpression.arguments
+        openParenIndent.goodChar + indentSize * OPTIONS.CallExpression.arguments
       );
     }
     super.visitCallExpression(node);

--- a/src/test/rules/terIndentRuleTests.ts
+++ b/src/test/rules/terIndentRuleTests.ts
@@ -3349,4 +3349,63 @@ ruleTester.addTestGroup('interfaces', 'should check indentation on interfaces', 
   }
 ]);
 
+ruleTester.addTestGroupWithConfig(
+  'issue-254',
+  'reporting as a false positive',
+  [
+    2,
+    {
+      'SwitchCase': 1,
+      'MemberExpression': 1,
+      'FunctionDeclaration': {
+        'parameters': 1
+      },
+      'FunctionExpression': {
+        'parameters': 1
+      },
+      'CallExpression': {
+        arguments: 1
+      }
+    }
+  ],
+  [
+    {
+      code: dedent`
+      foo = this.actions$
+        .ofType(
+          'foo',
+          'bar'
+        );
+      `
+    },
+    {
+      code: dedent`
+      foo = this
+        .actions$
+        .ofType(
+          'foo',
+          'bar'
+        );
+      `
+    },
+    {
+      code: dedent`
+      foo = this.actions$.ofType(
+        'foo',
+        'bar'
+      );
+      `
+    },
+    {
+      code: dedent`
+      foo = this.actions$.ofType
+        (
+          'foo',
+          'bar'
+        );
+      `
+    }
+  ]
+);
+
 ruleTester.runTests();


### PR DESCRIPTION
The call expression may contain a chain of properties, for instance
`this.prop.other.fun(`. Sometimes we like to break these chains so that
the parenthesis start in another line. The indentation should follow
from the indentation on the open parens and not the caller.