### PR TITLE
[feat] added default gulp build task and run single test launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,25 @@
         "NODE_ENV": "development"
       },
       "sourceMaps": true,
-      "outDir": "${workspaceRoot}/dist",
+      "outFiles": ["${workspaceRoot}/dist"],
+      "request": "launch"
+    },
+    {
+      "name": "single test",
+      "type": "node",
+      "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+      "stopOnEntry": false,
+      "args": [
+        "dist/test/rules/${fileBasenameNoExtension}.js"
+      ],
+      "cwd": "${workspaceRoot}/.",
+      "runtimeExecutable": null,
+      "preLaunchTask": "build",
+      "env": {
+        "NODE_ENV": "development"
+      },
+      "sourceMaps": true,
+      "outFiles": ["${workspaceRoot}/dist"],
       "request": "launch"
     }
   ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "gulp",
+      "task": "build",
+      "label": "build",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The build task was not defined in `tasks.json`
So, running `test` configuration from launch.json shows the following error:

![screen shot 2017-11-20 at 7 40 40 pm](https://user-images.githubusercontent.com/16024985/33053850-b4a68916-ce2a-11e7-8c29-c9cc3f3875db.png)

The default `build` task in `tasks.json` fixes it.

Also, the `test` configuration runs all tests - it takes time to hit the breakpoints.
The `single test` configuration runs test for currently opened test file as follows:

![single-test-screen-recording 1](https://user-images.githubusercontent.com/16024985/33054359-8f8607e4-ce2d-11e7-8531-b9cdd75cf0f6.gif)