### PR TITLE
Remove [ from "ter-no-mixed-spaces-and-tabs"

### DIFF
--- a/src/docs/rules/terNoMixedSpacesAndTabsRule.md
+++ b/src/docs/rules/terNoMixedSpacesAndTabsRule.md
@@ -33,19 +33,19 @@ allow mixing tabs and spaces if tabs are used for indentation and spaces for ali
 #### Examples
 
 ```json
-"ter-no-mixed-spaces-and-tabs": { "type": "tabs" } ]
+"ter-no-mixed-spaces-and-tabs": { "type": "tabs" }
 ```
 
 ```json
-"ter-no-mixed-spaces-and-tabs": { "type": "spaces" } ]
+"ter-no-mixed-spaces-and-tabs": { "type": "spaces" }
 ```
 
 ```json
-"ter-no-mixed-spaces-and-tabs": { "smartTabs": true } ]
+"ter-no-mixed-spaces-and-tabs": { "smartTabs": true }
 ```
 
 ```json
-"ter-no-mixed-spaces-and-tabs": { "type": "tabs", "smartTabs": true } ]
+"ter-no-mixed-spaces-and-tabs": { "type": "tabs", "smartTabs": true }
 ```
 #### Schema
 


### PR DESCRIPTION
Remove the extra `]` from `ter-no-mixed-spaces-and-tabs` because it only accepts object