### PR TITLE
[feat] Enhance valid-jsdoc to recognize @inheritDoc tag as an override

### DIFF
--- a/src/rules/validJsdocRule.ts
+++ b/src/rules/validJsdocRule.ts
@@ -372,6 +372,7 @@ class ValidJsdocWalker extends Lint.RuleWalker {
           break;
         case 'override':
         case 'inheritdoc':
+        case 'inheritDoc':
           isOverride = true;
           break;
       }

--- a/src/test/rules/validJsdocRuleTests.ts
+++ b/src/test/rules/validJsdocRuleTests.ts
@@ -102,9 +102,13 @@ ruleTester.addTestGroup('valid-default', 'should pass when using valid JSDoc com
     * Description
     * @override */
     function foo(arg1, arg2){ return ''; }`,
-  `/**
+    `/**
     * Description
     * @inheritdoc */
+    function foo(arg1, arg2){ return ''; }`,
+    `/**
+    * Description
+    * @inheritDoc */
     function foo(arg1, arg2){ return ''; }`,
   `/**
     * Description
@@ -414,6 +418,16 @@ ruleTester.addTestGroup('invalid', 'should fail when using invalid JSDoc comment
       /**
        * Foo
        * @inheritdoc
+       * @param {string} a desc
+        */
+       function foo(b){}`,
+    errors: expecting(["expected JSDoc for 'b' but found 'a'"])
+  },
+  {
+    code: dedent`
+      /**
+       * Foo
+       * @inheritDoc
        * @param {string} a desc
         */
        function foo(b){}`,


### PR DESCRIPTION
The valid-jsdoc rule currently recognizes `@inheritdoc` as a tag that indicates that a method/property is an override, but it does not recognize the common variant `@inheritDoc`. This PR adds support for recognizing `@inheritDoc`.