### PR TITLE
[fix] the imported object name was not being trimmed (Closes #319)

### DIFF
--- a/src/rules/sortImportsRule.ts
+++ b/src/rules/sortImportsRule.ts
@@ -140,23 +140,24 @@ class RuleWalker extends Lint.RuleWalker {
   private _validateOrder(node: ts.ImportDeclaration | ts.ImportEqualsDeclaration) {
     const importData = this._determineImportType(node);
     if (importData) {
+      const importName = importData.sortValue.trim();
       // See if the import type is still available
       const index = this.expectedOrder.indexOf(importData.memberSyntaxType, this.currentImportIndex);
       if (index !== -1) {
         if (this.expectedOrder[this.currentImportIndex] !== importData.memberSyntaxType) {
           this.currentImportIndex = index;
           this.currentSortValue = {
-            sortValue: this.caseConverter(importData.sortValue),
-            originalValue: importData.sortValue
+            sortValue: this.caseConverter(importName),
+            originalValue: importName
           };
-        } else if (this.currentSortValue.sortValue > this.caseConverter(importData.sortValue)) {
+        } else if (this.currentSortValue.sortValue > this.caseConverter(importName)) {
           this.addFailureAtNode(
             node,
-            `All imports of the same type must be sorted alphabetically. "${importData.sortValue}" must come before "${this.currentSortValue.originalValue}"`);
+            `All imports of the same type must be sorted alphabetically. "${importName}" must come before "${this.currentSortValue.originalValue}"`);
         } else {
           this.currentSortValue = {
-            sortValue: this.caseConverter(importData.sortValue),
-            originalValue: importData.sortValue
+            sortValue: this.caseConverter(importName),
+            originalValue: importName
           };
         }
       } else {

--- a/src/test/rules/sortImportsRuleTests.ts
+++ b/src/test/rules/sortImportsRuleTests.ts
@@ -34,6 +34,22 @@ ruleTester.addTestGroup('valid', 'should pass ESLint valid tests', [
       import {b, c} from 'foo'`,
     options: [{ 'member-syntax-sort-order': ['single', 'multiple', 'none', 'all', 'alias'] }]
   },
+  {
+    code: dedent`
+      import createTheme from 'spectacle/lib/themes/default'
+      import {hot} from 'react-hot-loader'
+      import React from 'react'
+      `,
+    options: ['ignore-case']
+  },
+  {
+    code: dedent`
+      import createTheme from 'spectacle/lib/themes/default'
+      import { hot } from 'react-hot-loader'
+      import React from 'react'
+      `,
+    options: ['ignore-case']
+  },
   dedent`
     import {a, b} from 'bar';
     import {c, d} from 'foo';`,


### PR DESCRIPTION
Added two tests which should behave the same. If we do not trim the name then we won't be able to add space on the curly braces.