### PR TITLE
[fix] update version in package-lock.json (closes #339)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-eslint-rules",
-  "version": "5.0.0",
+  "version": "5.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
(text copied from Issue #339)

When I `npm install`ed, the package-json version updated. Perhaps some version bumps were done manually in `package.json` without updating the *lockfile* (as happens automatically with `npm version ____`).

```diff
 {
   "name": "tslint-eslint-rules",
-  "version": "5.0.0",
+  "version": "5.3.1",
    // ...
```