### PR TITLE
[fix] included typescript 3 in peerDependency version range (closes #332)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "tslint": "^5.0.0",
-    "typescript": "^2.2.0"
+    "typescript": "^2.2.0 || ^3.0.0"
   },
   "dependencies": {
     "doctrine": "0.7.2",


### PR DESCRIPTION
This should close #332

It updates the `package-json` to allow ts 3.0 as a peer dependency, preventing the following warning:

> warning " > tslint-eslint-rules@5.3.1" has incorrect peer dependency "typescript@^2.2.0".

```diff
   "peerDependencies": {
     "tslint": "^5.0.0",
-    "typescript": "^2.2.0"
+    "typescript": "^2.2.0 || ^3.0.0"
   },
```