### PR TITLE
[feat]: include dist/readme

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,7 +3,6 @@
 .idea
 .vs
 dist/test
-dist/readme
 dist/tools
 node_modules
 src


### PR DESCRIPTION
It was included in `tslint-eslint-rules` v5.3.x (probably unintentionally) but not in v5.4.0.

The `dist/readme/index.ts` is very useful metadata.
I made a tool to import ESLint config into TSLint using it.
https://github.com/teppeis/tslint-import-eslint-config
Please expose it!