### PR TITLE
[bug] fixed no-empty-character-class rule (closes #289)

### DIFF
--- a/src/rules/noEmptyCharacterClassRule.ts
+++ b/src/rules/noEmptyCharacterClassRule.ts
@@ -17,7 +17,7 @@ class NoEmptyCharacterClassWalker extends Lint.RuleWalker {
   }
 
   private validateEmptyCharacterClass(node: ts.LiteralExpression) {
-    if (!(/^\/([^\\[]|\\.|\[([^\\\]]|\\.)+\])*\/[gim]*$/.test(node.text))) {
+    if (!(/^\/([^\\[]|\\.|\[([^\\\]]|\\.)+\])*\/[gimu]*$/.test(node.text))) {
       this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
     }
   }

--- a/src/test/rules/noEmptyCharacterClassRuleTests.ts
+++ b/src/test/rules/noEmptyCharacterClassRuleTests.ts
@@ -13,7 +13,8 @@ const scripts = {
     'var foo = /[[]/;',
     'var foo = /[\\[a-z[]]/;',
     'var foo = /[\\-\\[\\]\\/\\{\\}\\(\\)\\*\\+\\?\\.\\\\^\\$\\|]/g;',
-    'var foo = /\\s*:\\s*/gim;'
+    'var foo = /\\s*:\\s*/gim;',
+    'var foo = /\u{1F4A9}/u;'
   ],
   invalid: [
     'var foo = /^abc[]/;',


### PR DESCRIPTION
Now it should work properly with unicode regexes as well.