### PR TITLE
[bug] fixed sort-imports rule (closes #363)

### DIFF
--- a/src/rules/sortImportsRule.ts
+++ b/src/rules/sortImportsRule.ts
@@ -238,7 +238,7 @@ class RuleWalker extends Lint.RuleWalker {
           // Warning: we have seen this one already - skip
         } else {
           usedOptions[t] = t;
-          if (memberSyntaxTypeMap[t]) {
+          if (memberSyntaxTypeMap[t] !== undefined) {
             order.push(memberSyntaxTypeMap[t]);
           }
         }

--- a/src/test/rules/sortImportsRuleTests.ts
+++ b/src/test/rules/sortImportsRuleTests.ts
@@ -36,6 +36,13 @@ ruleTester.addTestGroup('valid', 'should pass ESLint valid tests', [
   },
   {
     code: dedent`
+      import './index.css';
+      import A from 'bar';
+      import {b, c} from 'foo'`,
+    options: [{ 'member-syntax-sort-order': ['none', 'all', 'single', 'multiple', 'alias'] }]
+  },
+  {
+    code: dedent`
       import createTheme from 'spectacle/lib/themes/default'
       import {hot} from 'react-hot-loader'
       import React from 'react'


### PR DESCRIPTION
Discovered that 'none' option is being skipped when sorting, as the enum evaluates to 0 which is considered false, so it is not added to the sort order. This allows a bug that will falsely say that 'none' must come before 'all' even when 'none' is the first value.