### PR TITLE
Fixed Typo

### DIFF
--- a/src/docs/rules/terComputedPropertySpacingRule.md
+++ b/src/docs/rules/terComputedPropertySpacingRule.md
@@ -24,11 +24,11 @@ The rule takes in one option, which defines to require or forbid whitespace.
 
 ```json
 "ter-computed-property-spacing": [true, "always"]
-      ```
+ ```
 
 ```json
 "ter-computed-property-spacing": [true, "never"]
-      ```
+```
 #### Schema
 
 ```json


### PR DESCRIPTION
Fixed typo that caused examples in ter-computed-property-spacing documentation to be displayed incorrectly