### PR TITLE
no-empty-character-class false positive with unicode regexps #289

### DIFF
--- a/src/rules/noEmptyCharacterClassRule.ts
+++ b/src/rules/noEmptyCharacterClassRule.ts
@@ -17,7 +17,7 @@ class NoEmptyCharacterClassWalker extends Lint.RuleWalker {
   }
 
   private validateEmptyCharacterClass(node: ts.LiteralExpression) {
-    if (!(/^\/([^\\[]|\\.|\[([^\\\]]|\\.)+\])*\/[gim]*$/.test(node.text))) {
+    if (!(/^\/([^\\[]|\\.|\[([^\\\]]|\\.)+\])*\/[gimus]*$/.test(node.text))) {
       this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
     }
   }

--- a/src/test/rules/noEmptyCharacterClassRuleTests.ts
+++ b/src/test/rules/noEmptyCharacterClassRuleTests.ts
@@ -13,7 +13,9 @@ const scripts = {
     'var foo = /[[]/;',
     'var foo = /[\\[a-z[]]/;',
     'var foo = /[\\-\\[\\]\\/\\{\\}\\(\\)\\*\\+\\?\\.\\\\^\\$\\|]/g;',
-    'var foo = /\\s*:\\s*/gim;'
+    'var foo = /\\s*:\\s*/gim;',
+    'var foo = /\\s*:\\s*/s;',
+    'var foo = /\s+/u;'
   ],
   invalid: [
     'var foo = /^abc[]/;',


### PR DESCRIPTION
Closes
https://github.com/buzinas/tslint-eslint-rules/issues/376
https://github.com/buzinas/tslint-eslint-rules/issues/289

P.S.
Too late I've notices https://github.com/buzinas/tslint-eslint-rules/pull/356

the only diff - this one covers also `/s` cases